### PR TITLE
fix: include leading semicolon in comment token length

### DIFF
--- a/internal/server/semantic.go
+++ b/internal/server/semantic.go
@@ -295,10 +295,15 @@ func tokenizeForSemantics(content string) []semanticToken {
 			isPayee = false
 		}
 
+		length := uint32(lsputil.UTF16Len(tok.Value))
+		if tok.Type == parser.TokenComment {
+			length++
+		}
+
 		tokens = append(tokens, semanticToken{
 			line:      uint32(tok.Pos.Line - 1),
 			col:       uint32(tok.Pos.Column - 1),
-			length:    uint32(lsputil.UTF16Len(tok.Value)),
+			length:    length,
 			tokenType: semType,
 			modifiers: modifiers,
 		})

--- a/internal/server/semantic_test.go
+++ b/internal/server/semantic_test.go
@@ -251,3 +251,50 @@ func TestSemanticTokens_Delta(t *testing.T) {
 		t.Fatalf("unexpected result type: %T", deltaResult)
 	}
 }
+
+func TestSemanticTokens_CommentLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantLength uint32
+	}{
+		{
+			name:       "single semicolon comment",
+			content:    "; test",
+			wantLength: 6,
+		},
+		{
+			name:       "double semicolon comment",
+			content:    ";; test",
+			wantLength: 7,
+		},
+		{
+			name:       "triple semicolon comment",
+			content:    ";;; test",
+			wantLength: 8,
+		},
+		{
+			name:       "double semicolon with date",
+			content:    ";;  01-12",
+			wantLength: 9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := tokenizeForSemantics(tt.content)
+			require.NotEmpty(t, tokens)
+
+			var commentToken *semanticToken
+			for i := range tokens {
+				if tokens[i].tokenType == TokenTypeComment {
+					commentToken = &tokens[i]
+					break
+				}
+			}
+			require.NotNil(t, commentToken, "comment token not found")
+			assert.Equal(t, tt.wantLength, commentToken.length,
+				"comment length mismatch for %q", tt.content)
+		})
+	}
+}


### PR DESCRIPTION
The lexer sets tok.Pos at the first semicolon but tok.Value excludes it, causing semantic highlighting to miss the last character of comments. Adding +1 to length for TokenComment corrects the mismatch.