### PR TITLE
fix(analyzer): balance real and balanced-virtual postings independently

### DIFF
--- a/internal/analyzer/account_balance.go
+++ b/internal/analyzer/account_balance.go
@@ -39,7 +39,15 @@ func CalculateAccountBalancesFromTransactions(transactions []ast.Transaction) Ac
 			addBalance(p.Account.GetResolvedName(), p.Amount.Commodity.Symbol, p.Amount.Quantity)
 		}
 
-		if account, inferred, ok := inferElidedAmounts(tx); ok {
+		// Infer elided amounts within each balancing group independently, using
+		// the same grouping as the balance check so what is verified and what is
+		// inferred stay consistent.
+		realPostings, balancedVirtual := groupPostings(tx.Postings)
+		for _, group := range [][]ast.Posting{realPostings, balancedVirtual} {
+			account, inferred, ok := inferElidedAmounts(group)
+			if !ok {
+				continue
+			}
 			for commodity, quantity := range inferred {
 				addBalance(account, commodity, quantity)
 			}
@@ -50,24 +58,22 @@ func CalculateAccountBalancesFromTransactions(transactions []ast.Transaction) Ac
 }
 
 // inferElidedAmounts returns the account and per-commodity amounts inferred for
-// the single real posting that omits its amount, balancing the transaction.
-// It reuses the same posting-classification rules as the balance check, so what
-// is verified and what is inferred stay consistent. ok is false unless exactly
-// one real posting has an elided amount.
-func inferElidedAmounts(tx *ast.Transaction) (account string, amounts map[string]decimal.Decimal, ok bool) {
-	realPostings := filterRealPostings(tx.Postings)
-	inferredCount, inferredIdx := countInferredPostings(realPostings)
+// the single posting in a balancing group that omits its amount. The elided
+// amount balances its own group (real or balanced-virtual), not the transaction
+// as a whole. ok is false unless the group has exactly one elided posting.
+func inferElidedAmounts(group []ast.Posting) (account string, amounts map[string]decimal.Decimal, ok bool) {
+	inferredCount, inferredIdx := countInferredPostings(group)
 	if inferredCount != 1 {
 		return "", nil, false
 	}
 
 	amounts = make(map[string]decimal.Decimal)
-	for commodity, sum := range sumByCommodity(realPostings) {
+	for commodity, sum := range sumByCommodity(group) {
 		if sum.IsZero() {
 			continue
 		}
 		amounts[commodity] = sum.Neg()
 	}
 
-	return realPostings[inferredIdx].Account.GetResolvedName(), amounts, true
+	return group[inferredIdx].Account.GetResolvedName(), amounts, true
 }

--- a/internal/analyzer/account_balance_test.go
+++ b/internal/analyzer/account_balance_test.go
@@ -113,6 +113,28 @@ func TestCalculateAccountBalances_InferredMultiCommodity(t *testing.T) {
 	assert.Equal(t, decimal.NewFromInt(-20), balances["c"]["EUR"])
 }
 
+func TestCalculateAccountBalances_InferredWithinRealGroup(t *testing.T) {
+	// The elided real posting is inferred against the real group only. The
+	// balanced-virtual group (here summing to +20) must not skew the inferred
+	// amount: assets:cash balances the real postings ($50) to -$50, not the
+	// combined pool (-$70).
+	input := `2024-01-15 test
+    expenses:food  $50
+    assets:cash
+    [budget:food]  $-30
+    [budget:available]  $50`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	balances := CalculateAccountBalances(journal)
+
+	assert.Equal(t, decimal.NewFromInt(50), balances["expenses:food"]["$"])
+	assert.Equal(t, decimal.NewFromInt(-50), balances["assets:cash"]["$"])
+	assert.Equal(t, decimal.NewFromInt(-30), balances["budget:food"]["$"])
+	assert.Equal(t, decimal.NewFromInt(50), balances["budget:available"]["$"])
+}
+
 func TestCalculateAccountBalances_EmptyJournal(t *testing.T) {
 	input := ``
 

--- a/internal/analyzer/balance.go
+++ b/internal/analyzer/balance.go
@@ -9,47 +9,83 @@ import (
 func CheckBalance(tx *ast.Transaction, userTolerance decimal.Decimal) *BalanceResult {
 	result := NewBalanceResult()
 
-	realPostings := filterRealPostings(tx.Postings)
-	inferredCount, inferredIdx := countInferredPostings(realPostings)
+	realPostings, balancedVirtual := groupPostings(tx.Postings)
 
-	if inferredCount > 1 {
+	realGroup := checkPostingGroup(realPostings, userTolerance)
+	virtualGroup := checkPostingGroup(balancedVirtual, userTolerance)
+
+	if realGroup.multipleInferred || virtualGroup.multipleInferred {
 		result.Balanced = false
 		return result
 	}
 
-	result.InferredIdx = inferredIdx
-
-	balances := sumByCommodity(realPostings)
-
-	if inferredCount == 1 {
-		result.Balanced = true
-		return result
+	result.InferredIdx = realGroup.inferredIdx
+	if result.InferredIdx < 0 {
+		result.InferredIdx = virtualGroup.inferredIdx
 	}
 
-	precisions := maxPrecisionByCommodity(realPostings)
+	for commodity, diff := range realGroup.differences {
+		result.Differences[commodity] = diff
+	}
+	for commodity, diff := range virtualGroup.differences {
+		result.Differences[commodity] = diff
+	}
+	result.Balanced = len(result.Differences) == 0
 
+	return result
+}
+
+// groupPostings splits a transaction's postings into the two groups that must
+// each balance to zero independently: real postings and balanced (bracketed)
+// virtual postings. Unbalanced (parenthesized) virtual postings are exempt from
+// the balance rule and are omitted.
+func groupPostings(postings []ast.Posting) (real, balancedVirtual []ast.Posting) {
+	for _, p := range postings {
+		switch p.Virtual {
+		case ast.VirtualNone:
+			real = append(real, p)
+		case ast.VirtualBalanced:
+			balancedVirtual = append(balancedVirtual, p)
+		}
+	}
+	return real, balancedVirtual
+}
+
+// postingGroupResult captures the balance outcome of a single posting group.
+type postingGroupResult struct {
+	multipleInferred bool
+	inferredIdx      int
+	differences      map[string]decimal.Decimal
+}
+
+// checkPostingGroup balances one posting group (real or balanced-virtual) per
+// the hledger rules: a single elided posting is inferred and always balances;
+// more than one cannot be inferred; otherwise the group must sum to zero within
+// each commodity's tolerance.
+func checkPostingGroup(postings []ast.Posting, userTolerance decimal.Decimal) postingGroupResult {
+	inferredCount, inferredIdx := countInferredPostings(postings)
+	if inferredCount > 1 {
+		return postingGroupResult{multipleInferred: true, inferredIdx: -1}
+	}
+	if inferredCount == 1 {
+		return postingGroupResult{inferredIdx: inferredIdx}
+	}
+
+	balances := sumByCommodity(postings)
+	precisions := maxPrecisionByCommodity(postings)
+
+	differences := make(map[string]decimal.Decimal)
 	for commodity, sum := range balances {
 		tolerance := toleranceForPrecision(precisions[commodity])
 		if userTolerance.IsPositive() && userTolerance.GreaterThan(tolerance) {
 			tolerance = userTolerance
 		}
 		if sum.Abs().GreaterThanOrEqual(tolerance) {
-			result.Balanced = false
-			result.Differences[commodity] = sum.Abs()
+			differences[commodity] = sum.Abs()
 		}
 	}
 
-	return result
-}
-
-func filterRealPostings(postings []ast.Posting) []ast.Posting {
-	var real []ast.Posting
-	for _, p := range postings {
-		if p.Virtual == ast.VirtualNone || p.Virtual == ast.VirtualBalanced {
-			real = append(real, p)
-		}
-	}
-	return real
+	return postingGroupResult{inferredIdx: -1, differences: differences}
 }
 
 func countInferredPostings(postings []ast.Posting) (count int, lastIdx int) {

--- a/internal/analyzer/balance_test.go
+++ b/internal/analyzer/balance_test.go
@@ -131,7 +131,95 @@ func TestCheckBalance_WithCost_TotalPrice(t *testing.T) {
 }
 
 func TestCheckBalance_VirtualUnbalanced_Exempt(t *testing.T) {
-	t.Skip("Parser does not yet support virtual postings (task 3.4)")
+	// hledger: unbalanced (parenthesized) virtual postings are exempt from the
+	// balance rule; the real postings balance on their own.
+	input := `2024-01-15 test
+    expenses:food  $50
+    assets:cash  $-50
+    (tracking:note)  $999`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+	require.Len(t, journal.Transactions, 1)
+
+	result := CheckBalance(&journal.Transactions[0], decimal.Zero)
+
+	assert.True(t, result.Balanced, "unbalanced virtual postings must be exempt from balancing")
+}
+
+func TestCheckBalance_BalancedVirtual_NotCombinedWithReal(t *testing.T) {
+	// hledger rejects this: the real postings sum to +50 and the balanced
+	// virtual postings sum to -50. They must balance to zero independently, not
+	// cancel each other out.
+	input := `2024-01-15 bad
+    expenses:food  $100
+    assets:cash  $-50
+    [budget:x]  $-50`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+	require.Len(t, journal.Transactions, 1)
+
+	result := CheckBalance(&journal.Transactions[0], decimal.Zero)
+
+	assert.False(t, result.Balanced, "balanced virtual postings must not cancel real postings")
+	assert.Equal(t, decimal.NewFromInt(50), result.Differences["$"])
+}
+
+func TestCheckBalance_BalancedVirtual_IndependentlyBalanced(t *testing.T) {
+	// Both the real group and the balanced-virtual group sum to zero on their
+	// own → balanced.
+	input := `2024-01-15 ok
+    expenses:food  $50
+    assets:cash  $-50
+    [budget:food]  $-50
+    [budget:available]  $50`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+	require.Len(t, journal.Transactions, 1)
+
+	result := CheckBalance(&journal.Transactions[0], decimal.Zero)
+
+	assert.True(t, result.Balanced, "real and balanced-virtual groups balance independently")
+}
+
+func TestCheckBalance_BalancedVirtual_GroupUnbalanced(t *testing.T) {
+	// Real postings balance, but the balanced-virtual group sums to +20 →
+	// unbalanced, reported against the balanced-virtual group.
+	input := `2024-01-15 bad
+    expenses:food  $50
+    assets:cash  $-50
+    [budget:food]  $-30
+    [budget:available]  $50`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+	require.Len(t, journal.Transactions, 1)
+
+	result := CheckBalance(&journal.Transactions[0], decimal.Zero)
+
+	assert.False(t, result.Balanced, "balanced-virtual group must balance to zero on its own")
+	assert.Equal(t, decimal.NewFromInt(20), result.Differences["$"])
+}
+
+func TestCheckBalance_InferredWithBalancedVirtual(t *testing.T) {
+	// A single elided posting in the real group is inferred against the real
+	// group only; the balanced-virtual group balances on its own.
+	input := `2024-01-15 test
+    expenses:food  $50
+    assets:cash
+    [budget:food]  $-50
+    [budget:available]  $50`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+	require.Len(t, journal.Transactions, 1)
+
+	result := CheckBalance(&journal.Transactions[0], decimal.Zero)
+
+	assert.True(t, result.Balanced, "elided real posting inferred within the real group")
+	assert.GreaterOrEqual(t, result.InferredIdx, 0)
 }
 
 func TestCheckBalance_ZeroAmount(t *testing.T) {


### PR DESCRIPTION
## What

Fixes the virtual-posting false negative from #31: `CheckBalance` summed real
and bracketed (`[...]`) virtual postings in a single pool, so a transaction
whose real postings were off could be masked by an equal-and-opposite
balanced-virtual group and wrongly reported as balanced.

```
2024-01-15 bad
    expenses:food     $100
    assets:cash       $-50
    [budget:x]        $-50   ; real = +50, bracket = -50 → combined 0, wrongly accepted
```

hledger 1.52.1 rejects this:

```
The real postings' sum should be 0 but is: $50
The balanced virtual postings' sum should be 0 but is: $-50
```

## How

Introduce an explicit posting-group model — real (`VirtualNone`) and
balanced-virtual (`VirtualBalanced`), with unbalanced-virtual
(`VirtualUnbalanced`) exempt — and balance each group independently in
`CheckBalance`. The same grouping is reused in `inferElidedAmounts`, so an
elided posting is inferred within its own group and account balances (hover,
completion docs) stay consistent with what is validated.

## Scope note: cost-precision half of #31 is not a bug

The issue's second claim — that cost-posting precision is taken from the wrong
amount — does not hold against real hledger. Verified with the hledger 1.52.1
binary:

- The issue's own example `assets:stocks 3 AAPL @ $33.40 / assets:cash $-100`
  is **accepted** by hledger (balanced), matching our current behavior.
- The existing tests `TestCheckBalance_CostPrecisionExcluded`,
  `TestCheckBalance_CostRounding_WithinTolerance`, etc. match hledger 1.52.1.
- Applying the issue's proposed fix (precision from the cost amount) would make
  us **diverge** from hledger: e.g. `3.0000 AAPL @ $33.40 / $-100` is accepted
  by hledger but would be rejected under the proposed change.

So this PR implements only the confirmed virtual-posting fix; cost-precision
behavior is left unchanged.

## Verification

- Red tests first: `TestCheckBalance_BalancedVirtual_NotCombinedWithReal`
  (the issue's example) and `TestCalculateAccountBalances_InferredWithinRealGroup`
  failed before the fix, pass after.
- New cases cross-checked against hledger 1.52.1 (independent balancing,
  unbalanced-virtual exempt, elided posting within a group).
- `go build ./...`, `go test -race ./...`, `golangci-lint run ./...` — all green.

Partially addresses #31 (virtual-posting half).