### PR TITLE
feat(release): sign release artifacts with minisign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           go-version: "1.24"
 
+      - name: Install minisign
+        run: sudo apt-get update && sudo apt-get install -y minisign
+
+      - name: Write signing key
+        run: |
+          echo "${{ secrets.MINISIGN_PRIVATE_KEY }}" | base64 -d > /tmp/minisign.key
+          chmod 600 /tmp/minisign.key
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,19 @@ checksum:
   name_template: checksums.txt
   algorithm: sha256
 
+signs:
+  - cmd: minisign
+    args:
+      - -S
+      - -s
+      - /tmp/minisign.key
+      - -m
+      - ${artifact}
+      - -x
+      - ${signature}
+    signature: ${artifact}.minisig
+    artifacts: all
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary

Release artifacts are not signed. The VS Code extension (`hledger-vscode`) verifies SHA-256 checksums from `checksums.txt`, but both the binary and the checksum come from the same GitHub release. A compromised release pipeline can replace both simultaneously.

This PR adds **minisign (Ed25519) signing** to the goreleaser release pipeline. Each binary artifact gets a `.minisig` signature file that the extension verifies before installation.

## Changes

### `.goreleaser.yaml`

Added `signs:` section:
```yaml
signs:
  - cmd: minisign
    args: [-S, -s, /tmp/minisign.key, -m, ${artifact}, -x, ${signature}]
    signature: ${artifact}.minisig
    artifacts: all
```

### `.github/workflows/release.yml`

Added two steps before goreleaser:
1. **Install minisign** — `apt-get install minisign`
2. **Write signing key** — decodes `MINISIGN_PRIVATE_KEY` secret (base64) to `/tmp/minisign.key`

## Setup required before merge

1. Generate a minisign key pair (one-time, local):
   ```bash
   minisign -G -W -f minisign.key
   # Public key printed to stdout → embed in hledger-vscode signingKey.ts
   # Private key file → base64-encode → GitHub Actions secret
   ```

2. Add the secret:
   ```bash
   base64 < minisign.key | gh secret set MINISIGN_PRIVATE_KEY -R juev/hledger-lsp
   ```

3. Update `MINISIGN_PUBLIC_KEY` in `hledger-vscode/src/extension/lsp/signingKey.ts` with the real public key.

## Result

Each release will include `.minisig` files alongside binaries:
```
hledger-lsp_darwin_arm64
hledger-lsp_darwin_arm64.minisig   ← NEW
hledger-lsp_linux_amd64
hledger-lsp_linux_amd64.minisig    ← NEW
...
```

## Related

- Closes #47
- Requires: juev/hledger-vscode#226 (verification in the extension)
