### PR TITLE
fix(server): run CLI code action against the invoking journal

### DIFF
--- a/internal/server/code_action.go
+++ b/internal/server/code_action.go
@@ -36,7 +36,7 @@ func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionPara
 		return nil, nil
 	}
 
-	actions := s.getCodeActions()
+	actions := s.getCodeActions(params.TextDocument.URI)
 	quickFixes := s.getQuickFixCodeActions(params)
 
 	result := make([]protocol.CodeAction, 0, len(actions)+len(quickFixes))
@@ -163,7 +163,7 @@ func (s *Server) quickFixForUnbalanced(
 	}, true
 }
 
-func (s *Server) getCodeActions() []protocol.CodeAction {
+func (s *Server) getCodeActions(uri protocol.DocumentURI) []protocol.CodeAction {
 	settings := s.getSettings()
 	if s.cliClient == nil || !s.cliClient.Available() || !settings.CLI.Enabled {
 		return nil
@@ -179,8 +179,12 @@ func (s *Server) getCodeActions() []protocol.CodeAction {
 			Command: &protocol.Command{
 				Title:   cmd.title,
 				Command: "hledger.run",
+				// The invoking document URI is carried alongside the command so
+				// ExecuteCommand can target the journal the action came from
+				// (LSP ExecuteCommandParams has no URI field of its own).
 				Arguments: []any{
 					cmd.cmd,
+					string(uri),
 				},
 			},
 		})
@@ -207,17 +211,7 @@ func (s *Server) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCom
 		return nil, fmt.Errorf("hledger not available")
 	}
 
-	var filePath string
-	s.documents.Range(func(key, _ any) bool {
-		docURI := key.(protocol.DocumentURI)
-		path := uriToPath(docURI)
-		if path != "" {
-			filePath = path
-			return false
-		}
-		return true
-	})
-
+	filePath := s.resolveCommandFile(params.Arguments)
 	if filePath == "" {
 		return nil, fmt.Errorf("no document open")
 	}
@@ -228,6 +222,33 @@ func (s *Server) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCom
 	}
 
 	return formatOutputAsComment(cmd, output), nil
+}
+
+// resolveCommandFile determines which journal file an hledger.run command
+// targets. getCodeActions passes the invoking document URI as the second
+// argument; when present and resolvable it wins, so a command runs against the
+// journal it was invoked from even with multiple documents open. Without a
+// usable URI (e.g. a client that omits it) it falls back to the first open
+// document, preserving the legacy behavior.
+func (s *Server) resolveCommandFile(args []any) string {
+	if len(args) >= 2 {
+		if rawURI, ok := args[1].(string); ok && rawURI != "" {
+			if path := uriToPath(protocol.DocumentURI(rawURI)); path != "" {
+				return path
+			}
+		}
+	}
+
+	var filePath string
+	s.documents.Range(func(key, _ any) bool {
+		docURI := key.(protocol.DocumentURI)
+		if path := uriToPath(docURI); path != "" {
+			filePath = path
+			return false
+		}
+		return true
+	})
+	return filePath
 }
 
 func formatOutputAsComment(cmd, output string) string {

--- a/internal/server/code_action_test.go
+++ b/internal/server/code_action_test.go
@@ -1,12 +1,32 @@
 package server
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+
 	"github.com/juev/hledger-lsp/internal/cli"
 )
+
+// fakeCLIClient is a cliRunner that records the file path it was asked to run
+// against, so tests can assert which journal a command targeted without the
+// real hledger binary.
+type fakeCLIClient struct {
+	available bool
+	lastFile  string
+}
+
+func (f *fakeCLIClient) Available() bool { return f.available }
+
+func (f *fakeCLIClient) Run(_ context.Context, file string, _ ...string) (string, error) {
+	f.lastFile = file
+	return "", nil
+}
 
 func TestFormatOutputAsComment(t *testing.T) {
 	tests := []struct {
@@ -88,7 +108,7 @@ func TestServer_CodeAction_WithoutCLI(t *testing.T) {
 		cliClient: nil,
 	}
 
-	actions := s.getCodeActions()
+	actions := s.getCodeActions("file:///test.journal")
 	if len(actions) != 0 {
 		t.Errorf("expected no actions without CLI client, got %d", len(actions))
 	}
@@ -99,7 +119,7 @@ func TestServer_CodeAction_CLINotAvailable(t *testing.T) {
 		cliClient: cli.NewClient("/nonexistent/hledger", 5*time.Second),
 	}
 
-	actions := s.getCodeActions()
+	actions := s.getCodeActions("file:///test.journal")
 	if len(actions) != 0 {
 		t.Errorf("expected no actions with unavailable CLI, got %d", len(actions))
 	}
@@ -113,7 +133,7 @@ func TestServer_CodeAction_WithCLI(t *testing.T) {
 		t.Skip("hledger not available")
 	}
 
-	actions := s.getCodeActions()
+	actions := s.getCodeActions("file:///test.journal")
 	if len(actions) == 0 {
 		t.Error("expected code actions with CLI client")
 	}
@@ -171,4 +191,62 @@ func TestFooterLine(t *testing.T) {
 	if len(footer) != len(header) {
 		t.Errorf("footer length (%d) should match header length (%d)", len(footer), len(header))
 	}
+}
+
+func TestGetCodeActions_EmbedsDocumentURI(t *testing.T) {
+	s := NewServer()
+	s.cliClient = &fakeCLIClient{available: true}
+
+	docURI := protocol.DocumentURI("file:///test.journal")
+	actions := s.getCodeActions(docURI)
+
+	require.NotEmpty(t, actions)
+	for _, action := range actions {
+		require.NotNil(t, action.Command)
+		require.Len(t, action.Command.Arguments, 2, "command must carry the invoking document URI")
+		assert.Equal(t, string(docURI), action.Command.Arguments[1])
+	}
+}
+
+func TestExecuteCommand_TargetsInvokingURI(t *testing.T) {
+	s := NewServer()
+	fake := &fakeCLIClient{available: true}
+	s.cliClient = fake
+
+	uriA := protocol.DocumentURI("file:///a.journal")
+	uriB := protocol.DocumentURI("file:///b.journal")
+	s.documents.Store(uriA, "2024-01-01 a\n    expenses  $1\n    assets\n")
+	s.documents.Store(uriB, "2024-01-01 b\n    expenses  $2\n    assets\n")
+
+	params := &protocol.ExecuteCommandParams{
+		Command:   "hledger.run",
+		Arguments: []any{"bal", string(uriB)},
+	}
+
+	// The command must target the invoking document (B). Before the fix the
+	// handler ranged over the open documents in arbitrary order, so repeat to
+	// surface that nondeterminism reliably.
+	for i := 0; i < 20; i++ {
+		_, err := s.ExecuteCommand(context.Background(), params)
+		require.NoError(t, err)
+		assert.Equal(t, uriToPath(uriB), fake.lastFile)
+	}
+}
+
+func TestExecuteCommand_FallbackWithoutURI(t *testing.T) {
+	s := NewServer()
+	fake := &fakeCLIClient{available: true}
+	s.cliClient = fake
+
+	uriA := protocol.DocumentURI("file:///a.journal")
+	s.documents.Store(uriA, "2024-01-01 a\n    expenses  $1\n    assets\n")
+
+	params := &protocol.ExecuteCommandParams{
+		Command:   "hledger.run",
+		Arguments: []any{"bal"},
+	}
+
+	_, err := s.ExecuteCommand(context.Background(), params)
+	require.NoError(t, err)
+	assert.Equal(t, uriToPath(uriA), fake.lastFile)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,13 @@ import (
 	"github.com/juev/hledger-lsp/internal/workspace"
 )
 
+// cliRunner is the subset of the hledger CLI client the server depends on.
+// It is an interface so tests can substitute a fake without the real binary.
+type cliRunner interface {
+	Available() bool
+	Run(ctx context.Context, file string, args ...string) (string, error)
+}
+
 type Server struct {
 	client                protocol.Client
 	documents             sync.Map
@@ -28,7 +35,7 @@ type Server struct {
 	loader                *include.Loader
 	rulesLoader           *rules.Loader
 	resolved              sync.Map
-	cliClient             *cli.Client
+	cliClient             cliRunner
 	rootURI               string
 	workspace             *workspace.Workspace
 	settings              serverSettings


### PR DESCRIPTION
Fixes #32.

## Problem

Running an hledger CLI command from a code action (`bal`/`reg`/`bs`/…) could execute against the wrong journal when more than one journal file is open. `ExecuteCommand` never received the originating document URI (LSP `ExecuteCommandParams` has no URI field), so it picked a file by ranging over `s.documents` (`sync.Map`), whose iteration order is arbitrary — silently wrong output.

## Fix

- `getCodeActions` now carries the invoking document URI as a second command argument.
- `ExecuteCommand` resolves the target file from that URI via a new `resolveCommandFile` helper, falling back to the first open document only when no usable URI is present (legacy behavior preserved).
- The `cliClient` field is now a small `cliRunner` interface so tests can assert the targeted file without the real hledger binary.

## Verification

- New tests in `internal/server/code_action_test.go`:
  - `TestGetCodeActions_EmbedsDocumentURI` — the command carries the invoking URI.
  - `TestExecuteCommand_TargetsInvokingURI` — with two open journals, the command targets the invoking one (failed before the fix, picking the other document).
  - `TestExecuteCommand_FallbackWithoutURI` — no URI argument → previous fallback preserved.
- `go build ./...`, `go test -race ./...`, `golangci-lint run ./...` all pass.