### PR TITLE
fix(formatter): align amounts by display width for CJK characters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,13 @@ This ensures continuity between sessions and clear visibility of what's done and
 
 ### Unicode
 
-Account names, descriptions and comments may contain CJK, Cyrillic, emoji and other multi-byte characters. Use `utf8.RuneCountInString` (not `len`) for display-width calculations, and `lsputil.UTF16Len` for LSP column offsets. Every new feature that touches text must include tests with non-ASCII (CJK, Cyrillic) input.
+Account names, descriptions and comments may contain CJK, Cyrillic, emoji and other multi-byte characters. Three different metrics apply — do not conflate them:
+
+- **Display width** (terminal cells, for visual column alignment): use the runewidth-based `displayWidth` helper in `internal/formatter` (East Asian Width via `go-runewidth`). A full-width CJK character occupies 2 cells. `utf8.RuneCountInString` is wrong here — it counts a CJK character as 1 and drifts amounts out of visual alignment.
+- **Rune count / positional arithmetic**: use `utf8.RuneCountInString` (not `len`, which counts bytes).
+- **LSP column offsets**: use `lsputil.UTF16Len`.
+
+Every new feature that touches text must include tests with non-ASCII (CJK, Cyrillic) input.
 
 ### Line Endings (LF / CRLF)
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.2
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.11.1
 	go.lsp.dev/jsonrpc2 v0.10.0
@@ -13,6 +14,7 @@ require (
 )
 
 require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bmatcuk/doublestar/v4 v4.9.2 h1:b0mc6WyRSYLjzofB2v/0cuDUZ+MqoGyH3r0dVij35GI=
 github.com/bmatcuk/doublestar/v4 v4.9.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -13,6 +15,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -5,6 +5,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/shopspring/decimal"
 	"go.lsp.dev/protocol"
 
@@ -15,6 +16,20 @@ import (
 const defaultIndentSize = 4
 const minSpaces = 2
 const minAssertionSpaces = 1
+
+// widthCondition is a fixed runewidth condition so formatting is deterministic
+// regardless of the server's locale. Full-width CJK characters always occupy
+// two cells; ambiguous-width characters are treated as narrow (the common
+// default for Western fonts/editors).
+var widthCondition = runewidth.NewCondition()
+
+// displayWidth returns the number of terminal cells s occupies when rendered:
+// full-width CJK characters count as two cells, unlike utf8.RuneCountInString
+// which counts them as one. Use it for visual alignment column math; keep
+// RuneCountInString for positional/UTF-16 arithmetic.
+func displayWidth(s string) int {
+	return widthCondition.StringWidth(s)
+}
 
 // Amount alignment targets for postings with cost notation (`@`/`@@`).
 // They select which amount anchors alignment:
@@ -323,7 +338,7 @@ func formatTransactionWithOpts(tx *ast.Transaction, mapper *lsputil.PositionMapp
 }
 
 func calculateAccountDisplayLength(p *ast.Posting) int {
-	accountLen := utf8.RuneCountInString(p.Account.Name)
+	accountLen := displayWidth(p.Account.Name)
 	switch p.Virtual {
 	case ast.VirtualBalanced, ast.VirtualUnbalanced:
 		accountLen += 2
@@ -338,7 +353,7 @@ func CalculateAlignmentColumn(postings []ast.Posting) int {
 			maxLen = accountLen
 		}
 	}
-	return utf8.RuneCountInString(defaultIndent) + maxLen + minSpaces
+	return displayWidth(defaultIndent) + maxLen + minSpaces
 }
 
 func CalculateGlobalAlignmentColumn(transactions []ast.Transaction) int {
@@ -350,7 +365,7 @@ func CalculateGlobalAlignmentColumn(transactions []ast.Transaction) int {
 			}
 		}
 	}
-	return utf8.RuneCountInString(defaultIndent) + maxLen + minSpaces
+	return displayWidth(defaultIndent) + maxLen + minSpaces
 }
 
 // CalculateGlobalAlignmentColumnWithIndent returns the column at which amounts
@@ -600,9 +615,9 @@ func calculateSingleAmountDecimalPrefix(amount *ast.Amount, commodityFormats map
 	effectiveQty := qty
 
 	if position == ast.CommodityLeft {
-		symbolRuneLen := utf8.RuneCountInString(symbol)
+		symbolWidth := displayWidth(symbol)
 		if amount.SignBeforeCommodity && len(qty) > 0 && (qty[0] == '-' || qty[0] == '+') {
-			prefixBeforeQty = 1 + symbolRuneLen // sign + symbol
+			prefixBeforeQty = 1 + symbolWidth // sign + symbol
 			if spaceBetween {
 				prefixBeforeQty++
 			}
@@ -613,7 +628,7 @@ func calculateSingleAmountDecimalPrefix(amount *ast.Amount, commodityFormats map
 				qtyDecimalIdx = -1
 			}
 		} else {
-			prefixBeforeQty = symbolRuneLen
+			prefixBeforeQty = symbolWidth
 			if spaceBetween {
 				prefixBeforeQty++
 			}
@@ -625,7 +640,7 @@ func calculateSingleAmountDecimalPrefix(amount *ast.Amount, commodityFormats map
 	}
 
 	// No decimal — prefix is the full integer part
-	return prefixBeforeQty + utf8.RuneCountInString(effectiveQty)
+	return prefixBeforeQty + displayWidth(effectiveQty)
 }
 
 func resolveDecimalMark(amount *ast.Amount, commodityFormats map[string]CommodityFormat) rune {
@@ -642,8 +657,8 @@ func resolveDecimalMark(amount *ast.Amount, commodityFormats map[string]Commodit
 
 func calculateSingleAmountLen(amount *ast.Amount, commodityFormats map[string]CommodityFormat) int {
 	_, spaceBetween := resolveCommodityDisplay(amount, commodityFormats)
-	symbolLen := utf8.RuneCountInString(commoditySymbolDisplay(&amount.Commodity))
-	qtyLen := utf8.RuneCountInString(formatAmountQuantity(amount, commodityFormats))
+	symbolLen := displayWidth(commoditySymbolDisplay(&amount.Commodity))
+	qtyLen := displayWidth(formatAmountQuantity(amount, commodityFormats))
 	length := qtyLen
 
 	if symbolLen > 0 {
@@ -696,15 +711,15 @@ func formatPostingWithOpts(posting *ast.Posting, alignment AlignmentInfo, commod
 		spaces := minSpaces
 		switch {
 		case alignAmounts && alignment.DecimalCol > 0:
-			currentLen := utf8.RuneCountInString(sb.String())
+			currentLen := displayWidth(sb.String())
 			prefix := calculateAlignmentTargetDecimalPrefix(posting, commodityFormats, target)
 			spaces = max(alignment.DecimalCol-currentLen-prefix, minSpaces)
 		case alignAmounts && alignment.AmountEndCol > 0:
-			currentLen := utf8.RuneCountInString(sb.String())
+			currentLen := displayWidth(sb.String())
 			amountLen := calculateAlignmentTargetLen(posting, commodityFormats, target)
 			spaces = max(alignment.AmountEndCol-currentLen-amountLen, minSpaces)
 		case alignAmounts && alignment.AccountCol > 0:
-			currentLen := utf8.RuneCountInString(sb.String())
+			currentLen := displayWidth(sb.String())
 			spaces = max(alignment.AccountCol-currentLen, minSpaces)
 		}
 		sb.WriteString(strings.Repeat(" ", spaces))
@@ -730,7 +745,7 @@ func formatPostingWithOpts(posting *ast.Posting, alignment AlignmentInfo, commod
 		if posting.Amount == nil {
 			spaces = minSpaces
 			if alignAmounts && alignment.AccountCol > 0 {
-				currentLen := utf8.RuneCountInString(sb.String())
+				currentLen := displayWidth(sb.String())
 				spaces = max(alignment.AccountCol-currentLen, minSpaces)
 			}
 		}

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,16 @@ import (
 	"github.com/juev/hledger-lsp/internal/lsputil"
 	"github.com/juev/hledger-lsp/internal/parser"
 )
+
+// displayColumnOf returns the display (terminal cell) column at which substr
+// first appears in line, counting full-width CJK characters as two cells. It is
+// the width-aware counterpart of strings.Index used to assert visual alignment.
+func displayColumnOf(t *testing.T, line, substr string) int {
+	t.Helper()
+	idx := strings.Index(line, substr)
+	require.GreaterOrEqual(t, idx, 0, "line %q must contain %q", line, substr)
+	return runewidth.StringWidth(line[:idx])
+}
 
 func mustParse(t *testing.T, content string) *ast.Journal {
 	t.Helper()
@@ -3603,6 +3614,141 @@ func TestFormatDocument_DecimalAlignment_CJK(t *testing.T) {
 	edits2 := FormatDocumentWithOptions(journal2, result, nil, opts)
 	result2 := applyEdits(result, edits2)
 	assert.Equal(t, result, result2, "decimal alignment (CJK) must be idempotent")
+}
+
+// The CJK alignment tests below mix full-width (CJK) and ASCII account names of
+// differing widths. That mix is what exposes the bug: counting runes instead of
+// display cells aligns ASCII postings but drifts CJK ones out of the visual
+// column. Each test asserts positions in display cells (via displayColumnOf /
+// runewidth.StringWidth), not bytes or runes.
+
+func TestFormatDocument_CJKAlignment_NaturalColumn(t *testing.T) {
+	input := "2024-01-15 test\n" +
+		"    费用:食物  $50.00\n" +
+		"    assets:cash  $-50.00"
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	opts := Options{IndentSize: 4, AlignAmounts: true}
+	edits := FormatDocumentWithOptions(journal, input, nil, opts)
+	result := applyEdits(input, edits)
+
+	lines := strings.Split(result, "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t,
+		displayColumnOf(t, lines[1], "$50.00"),
+		displayColumnOf(t, lines[2], "$-50.00"),
+		"CJK and ASCII amounts must align to one visual column:\n%s", result)
+
+	journal2, errs := parser.Parse(result)
+	require.Empty(t, errs)
+	edits2 := FormatDocumentWithOptions(journal2, result, nil, opts)
+	result2 := applyEdits(result, edits2)
+	assert.Equal(t, result, result2, "natural CJK alignment must be idempotent")
+}
+
+func TestFormatDocument_CJKAlignment_LeftMode(t *testing.T) {
+	input := "2024-01-15 test\n" +
+		"    费用:食物  $50.00\n" +
+		"    assets:cash  $-50.00"
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	opts := Options{IndentSize: 4, AlignAmounts: true, AmountAlignmentMode: "left", AmountAlignmentColumn: 30}
+	edits := FormatDocumentWithOptions(journal, input, nil, opts)
+	result := applyEdits(input, edits)
+
+	lines := strings.Split(result, "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, 30, displayColumnOf(t, lines[1], "$50.00"),
+		"CJK amount must start at the configured display column:\n%s", result)
+	assert.Equal(t, 30, displayColumnOf(t, lines[2], "$-50.00"),
+		"ASCII amount must start at the configured display column:\n%s", result)
+
+	journal2, errs := parser.Parse(result)
+	require.Empty(t, errs)
+	edits2 := FormatDocumentWithOptions(journal2, result, nil, opts)
+	result2 := applyEdits(result, edits2)
+	assert.Equal(t, result, result2, "left CJK alignment must be idempotent")
+}
+
+func TestFormatDocument_CJKAlignment_RightMode(t *testing.T) {
+	input := "2024-01-15 test\n" +
+		"    费用:食物  50.00 USD\n" +
+		"    assets:cash  1200.00 USD"
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	opts := Options{IndentSize: 4, AlignAmounts: true, AmountAlignmentMode: "right", AmountAlignmentColumn: 40}
+	edits := FormatDocumentWithOptions(journal, input, nil, opts)
+	result := applyEdits(input, edits)
+
+	lines := strings.Split(result, "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, 40, runewidth.StringWidth(lines[1]),
+		"CJK amount must end at the configured display column:\n%s", result)
+	assert.Equal(t, 40, runewidth.StringWidth(lines[2]),
+		"ASCII amount must end at the configured display column:\n%s", result)
+
+	journal2, errs := parser.Parse(result)
+	require.Empty(t, errs)
+	edits2 := FormatDocumentWithOptions(journal2, result, nil, opts)
+	result2 := applyEdits(result, edits2)
+	assert.Equal(t, result, result2, "right CJK alignment must be idempotent")
+}
+
+func TestFormatDocument_CJKAlignment_DecimalMode(t *testing.T) {
+	input := "2024-01-15 test\n" +
+		"    费用:食物  $1000.00\n" +
+		"    assets:cash  $5.76"
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	opts := Options{IndentSize: 4, AlignAmounts: true, AmountAlignmentMode: "decimal", AmountAlignmentColumn: 40}
+	edits := FormatDocumentWithOptions(journal, input, nil, opts)
+	result := applyEdits(input, edits)
+
+	lines := strings.Split(result, "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, 40, displayColumnOf(t, lines[1], "."),
+		"CJK decimal point must be at the configured display column:\n%s", result)
+	assert.Equal(t, 40, displayColumnOf(t, lines[2], "."),
+		"ASCII decimal point must be at the configured display column:\n%s", result)
+
+	journal2, errs := parser.Parse(result)
+	require.Empty(t, errs)
+	edits2 := FormatDocumentWithOptions(journal2, result, nil, opts)
+	result2 := applyEdits(result, edits2)
+	assert.Equal(t, result, result2, "decimal CJK alignment must be idempotent")
+}
+
+func TestFormatDocument_CJKAlignment_CRLF(t *testing.T) {
+	input := "2024-01-15 test\r\n    费用:食物  $50.00\r\n    assets:cash  $-50.00"
+	normalized := strings.ReplaceAll(input, "\r\n", "\n")
+
+	journal, errs := parser.Parse(normalized)
+	require.Empty(t, errs)
+
+	opts := Options{IndentSize: 4, AlignAmounts: true, AmountAlignmentMode: "left", AmountAlignmentColumn: 30}
+	edits := FormatDocumentWithOptions(journal, normalized, nil, opts)
+	result := applyEdits(normalized, edits)
+
+	lines := strings.Split(result, "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, 30, displayColumnOf(t, lines[1], "$50.00"),
+		"CJK amount must start at the configured display column (CRLF):\n%s", result)
+	assert.Equal(t, 30, displayColumnOf(t, lines[2], "$-50.00"),
+		"ASCII amount must start at the configured display column (CRLF):\n%s", result)
+
+	journal2, errs := parser.Parse(result)
+	require.Empty(t, errs)
+	edits2 := FormatDocumentWithOptions(journal2, result, nil, opts)
+	result2 := applyEdits(result, edits2)
+	assert.Equal(t, result, result2, "CRLF CJK alignment must be idempotent")
 }
 
 func TestCalculateGlobalDecimalCol(t *testing.T) {


### PR DESCRIPTION
Fixes #33.

## Problem

Amount alignment used `utf8.RuneCountInString` as the width metric. A full-width CJK character renders as two terminal cells but counts as one rune, so journals mixing CJK and ASCII account names did not align into a visual column — the CJK postings drifted right by one cell per wide character.

The existing CJK tests did not catch this: they use accounts of *equal* width, where rune-based padding coincidentally aligns (just at the wrong absolute column).

## Fix

- New `displayWidth` helper in `internal/formatter`, backed by `github.com/mattn/go-runewidth` (East Asian Width) with a fixed condition so output is deterministic regardless of server locale.
- Use it in every alignment-column calculation (`calculateAccountDisplayLength`, the global/per-transaction column functions, amount-length and decimal-prefix math) **and** in the space padding in `formatPostingWithOpts` that consumes those columns. Both sides must agree on display cells for the column to be visually correct.
- `RuneCountInString` is kept for positional/UTF-16 arithmetic.
- ASCII output is unchanged (display width == rune count); formatting stays idempotent.
- Corrected the `CLAUDE.md` Unicode guidance, which wrongly recommended `RuneCountInString` for display-width calculations.

## Verification

New tests in `internal/formatter/formatter_test.go` mix CJK (`费用:食物`) and ASCII (`assets:cash`) accounts and assert positions in **display cells** (via a `displayColumnOf` helper):
- `..._NaturalColumn` — auto column: both amounts land on one visual column.
- `..._LeftMode` / `..._RightMode` / `..._DecimalMode` — configured-column modes hit the exact display column.
- `..._CRLF` — CRLF variant.
- Each includes an idempotency check.

All five failed before the fix (CJK line off by exactly the wide-char excess, e.g. expected 30 / actual 34) and pass after.

`go build ./...`, `go test -race ./...`, `golangci-lint run ./...` all pass; no ASCII regression in the existing formatter/server suites.