### PR TITLE
fix(server): debounce diagnostics with per-URI cancellation and version

### DIFF
--- a/internal/server/benchmark_test.go
+++ b/internal/server/benchmark_test.go
@@ -343,7 +343,7 @@ func BenchmarkPublishDiagnostics_Small(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for b.Loop() {
-		srv.publishDiagnostics(ctx, docURI, smallContent)
+		srv.publishDiagnostics(ctx, docURI, smallContent, 0)
 	}
 }
 
@@ -354,7 +354,7 @@ func BenchmarkPublishDiagnostics_Medium(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for b.Loop() {
-		srv.publishDiagnostics(ctx, docURI, mediumContent)
+		srv.publishDiagnostics(ctx, docURI, mediumContent, 0)
 	}
 }
 
@@ -365,6 +365,6 @@ func BenchmarkPublishDiagnostics_Large(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for b.Loop() {
-		srv.publishDiagnostics(ctx, docURI, largeContent)
+		srv.publishDiagnostics(ctx, docURI, largeContent, 0)
 	}
 }

--- a/internal/server/diagnostics_debounce_test.go
+++ b/internal/server/diagnostics_debounce_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func TestDiagnostics_RapidEditsCoalesce(t *testing.T) {
+	srv := NewServer()
+	srv.diagDebounce = 80 * time.Millisecond
+	client := newIntegrationMockClient()
+	srv.SetClient(client)
+
+	docURI := protocol.DocumentURI("file:///test.journal")
+
+	err := srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:     docURI,
+			Version: 1,
+			Text:    "2024-01-15 test\n    expenses:food  $1\n    assets:cash",
+		},
+	})
+	require.NoError(t, err)
+
+	const edits = 10
+	for i := 2; i <= edits+1; i++ {
+		content := fmt.Sprintf("2024-01-15 test\n    expenses:food  $%d\n    assets:cash", i)
+		err = srv.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+			TextDocument: protocol.VersionedTextDocumentIdentifier{
+				TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
+				Version:                int32(i),
+			},
+			ContentChanges: []protocol.TextDocumentContentChangeEvent{{Text: content}},
+		})
+		require.NoError(t, err)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	require.True(t, client.waitDiagnostics(), "expected at least one diagnostics publish")
+	time.Sleep(50 * time.Millisecond)
+
+	client.mu.Lock()
+	count := len(client.diagnostics)
+	last := client.diagnostics[count-1]
+	client.mu.Unlock()
+
+	assert.Equal(t, 1, count, "rapid edits should coalesce into a single publish")
+	assert.Equal(t, uint32(edits+1), last.Version, "published version should match the last edit")
+}
+
+func TestDiagnostics_SupersededComputationNeverPublishes(t *testing.T) {
+	srv := NewServer()
+	srv.diagDebounce = 50 * time.Millisecond
+	client := newIntegrationMockClient()
+	srv.SetClient(client)
+
+	docURI := protocol.DocumentURI("file:///test.journal")
+
+	err := srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:     docURI,
+			Version: 1,
+			Text:    "2024-01-15 old\n    expenses:food  $999\n    assets:cash  $1",
+		},
+	})
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	err = srv.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
+			Version:                2,
+		},
+		ContentChanges: []protocol.TextDocumentContentChangeEvent{{
+			Text: "2024-01-15 new\n    expenses:food  $50\n    assets:cash",
+		}},
+	})
+	require.NoError(t, err)
+
+	require.True(t, client.waitDiagnostics(), "expected diagnostics publish")
+	time.Sleep(100 * time.Millisecond)
+
+	client.mu.Lock()
+	all := make([]protocol.PublishDiagnosticsParams, len(client.diagnostics))
+	copy(all, client.diagnostics)
+	client.mu.Unlock()
+
+	for _, pub := range all {
+		assert.Equal(t, uint32(2), pub.Version,
+			"stale version 1 must never be published after version 2 arrived")
+	}
+
+	last := all[len(all)-1]
+	assert.Empty(t, last.Diagnostics, "final content is balanced, should have no diagnostics")
+}
+
+func TestDiagnostics_PublishedVersionMatchesDocument(t *testing.T) {
+	srv := NewServer()
+	srv.diagDebounce = 0
+	client := newIntegrationMockClient()
+	srv.SetClient(client)
+
+	docURI := protocol.DocumentURI("file:///test.journal")
+
+	err := srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:     docURI,
+			Version: 7,
+			Text:    "2024-01-15 test\n    expenses:food  $50\n    assets:cash",
+		},
+	})
+	require.NoError(t, err)
+
+	require.True(t, client.waitDiagnostics())
+
+	last := client.getLastDiagnostics()
+	require.NotNil(t, last)
+	assert.Equal(t, uint32(7), last.Version)
+}
+
+func TestDiagnostics_DidCloseCancelsPending(t *testing.T) {
+	srv := NewServer()
+	srv.diagDebounce = 200 * time.Millisecond
+	client := newIntegrationMockClient()
+	srv.SetClient(client)
+
+	docURI := protocol.DocumentURI("file:///test.journal")
+
+	err := srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:     docURI,
+			Version: 1,
+			Text:    "2024-01-15 test\n    expenses:food  $50\n    assets:cash",
+		},
+	})
+	require.NoError(t, err)
+
+	err = srv.DidClose(context.Background(), &protocol.DidCloseTextDocumentParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+	})
+	require.NoError(t, err)
+
+	time.Sleep(300 * time.Millisecond)
+
+	client.mu.Lock()
+	count := len(client.diagnostics)
+	client.mu.Unlock()
+
+	assert.Equal(t, 0, count, "no diagnostics should be published after DidClose")
+}
+
+func TestDiagnostics_IndependentURIsDoNotInterfere(t *testing.T) {
+	srv := NewServer()
+	srv.diagDebounce = 50 * time.Millisecond
+	client := newIntegrationMockClient()
+	srv.SetClient(client)
+
+	uriA := protocol.DocumentURI("file:///a.journal")
+	uriB := protocol.DocumentURI("file:///b.journal")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_ = srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+			TextDocument: protocol.TextDocumentItem{
+				URI: uriA, Version: 1,
+				Text: "2024-01-15 a\n    expenses:food  $10\n    assets:cash",
+			},
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		_ = srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+			TextDocument: protocol.TextDocumentItem{
+				URI: uriB, Version: 1,
+				Text: "2024-01-15 b\n    expenses:rent  $20\n    assets:bank",
+			},
+		})
+	}()
+	wg.Wait()
+
+	require.True(t, client.waitDiagnostics())
+	require.True(t, client.waitDiagnostics())
+
+	client.mu.Lock()
+	count := len(client.diagnostics)
+	uris := map[protocol.DocumentURI]bool{}
+	for _, d := range client.diagnostics {
+		uris[d.URI] = true
+	}
+	client.mu.Unlock()
+
+	assert.Equal(t, 2, count, "each URI should get exactly one publish")
+	assert.True(t, uris[uriA])
+	assert.True(t, uris[uriB])
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
@@ -28,6 +29,12 @@ type cliRunner interface {
 	Run(ctx context.Context, file string, args ...string) (string, error)
 }
 
+// diagEntry tracks the pending debounced diagnostics computation for one URI.
+type diagEntry struct {
+	timer  *time.Timer
+	cancel context.CancelFunc
+}
+
 type Server struct {
 	client                protocol.Client
 	documents             sync.Map
@@ -43,13 +50,19 @@ type Server struct {
 	supportsConfiguration bool
 	payeeTemplatesCache   sync.Map // map[protocol.DocumentURI]map[string][]analyzer.PostingTemplate
 	alignmentCache        sync.Map // map[protocol.DocumentURI]int
+
+	diagDebounce time.Duration
+	diagMu       sync.Mutex
+	diagEntries  map[protocol.DocumentURI]*diagEntry
 }
 
 func NewServer() *Server {
 	srv := &Server{
-		analyzer:    analyzer.New(),
-		loader:      include.NewLoader(),
-		rulesLoader: rules.NewLoader(),
+		analyzer:     analyzer.New(),
+		loader:       include.NewLoader(),
+		rulesLoader:  rules.NewLoader(),
+		diagDebounce: 100 * time.Millisecond,
+		diagEntries:  make(map[protocol.DocumentURI]*diagEntry),
 	}
 	// Honour unsaved editor content for .rules files that are pulled in via
 	// transitive `include` from a currently-open rules file. The loader first
@@ -237,7 +250,7 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 	content := normalizeLineEndings(params.TextDocument.Text)
 	s.documents.Store(params.TextDocument.URI, content)
 	s.alignmentCache.Delete(params.TextDocument.URI)
-	go s.publishDiagnostics(ctx, params.TextDocument.URI, content)
+	s.scheduleDiagnostics(params.TextDocument.URI, content, uint32(params.TextDocument.Version))
 	return nil
 }
 
@@ -268,7 +281,7 @@ func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDo
 		if path := uriToPath(params.TextDocument.URI); path != "" && filetype.IsRules(path) {
 			s.rulesLoader.InvalidateFile(path)
 		}
-		go s.publishDiagnostics(ctx, params.TextDocument.URI, content)
+		s.scheduleDiagnostics(params.TextDocument.URI, content, uint32(params.TextDocument.Version))
 	}
 	return nil
 }
@@ -292,6 +305,7 @@ func (s *Server) clearAlignmentCache() {
 }
 
 func (s *Server) DidClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
+	s.cancelDiagnostics(params.TextDocument.URI)
 	s.documents.Delete(params.TextDocument.URI)
 	s.alignmentCache.Delete(params.TextDocument.URI)
 	tokenCache.delete(params.TextDocument.URI)
@@ -318,7 +332,43 @@ func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocume
 	return nil
 }
 
-func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.DocumentURI, content string) {
+// scheduleDiagnostics debounces diagnostics computation for the given URI.
+// A trailing timer coalesces rapid edits; the previous in-flight computation
+// is cancelled so a stale result never overwrites newer diagnostics.
+func (s *Server) scheduleDiagnostics(docURI protocol.DocumentURI, content string, version uint32) {
+	s.diagMu.Lock()
+	defer s.diagMu.Unlock()
+
+	if entry, ok := s.diagEntries[docURI]; ok {
+		entry.cancel()
+		entry.timer.Stop()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.diagEntries[docURI] = &diagEntry{
+		cancel: cancel,
+		timer: time.AfterFunc(s.diagDebounce, func() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			s.publishDiagnostics(ctx, docURI, content, version)
+		}),
+	}
+}
+
+func (s *Server) cancelDiagnostics(docURI protocol.DocumentURI) {
+	s.diagMu.Lock()
+	defer s.diagMu.Unlock()
+	if entry, ok := s.diagEntries[docURI]; ok {
+		entry.cancel()
+		entry.timer.Stop()
+		delete(s.diagEntries, docURI)
+	}
+}
+
+func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.DocumentURI, content string, version uint32) {
 	if s.client == nil {
 		return
 	}
@@ -327,6 +377,7 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.Documen
 	if !settings.Features.Diagnostics {
 		_ = s.client.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
 			URI:         docURI,
+			Version:     version,
 			Diagnostics: []protocol.Diagnostic{},
 		})
 		return
@@ -335,6 +386,7 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.Documen
 	if filetype.IsRules(string(docURI)) {
 		_ = s.client.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
 			URI:         docURI,
+			Version:     version,
 			Diagnostics: s.analyzeRules(content),
 		})
 		return
@@ -348,6 +400,10 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.Documen
 	s.resolved.Store(docURI, resolved)
 
 	diagnostics := s.analyze(path, content)
+
+	if ctx.Err() != nil {
+		return
+	}
 
 	for _, err := range loadErrors {
 		if err.Kind == include.ErrorParseError {
@@ -367,6 +423,7 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.Documen
 
 	_ = s.client.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
 		URI:         docURI,
+		Version:     version,
 		Diagnostics: diagnostics,
 	})
 }
@@ -521,7 +578,7 @@ func (s *Server) DidChangeWatchedFiles(ctx context.Context, params *protocol.Did
 
 	for docURI := range affected {
 		if content, ok := s.GetDocument(docURI); ok {
-			s.publishDiagnostics(ctx, docURI, content)
+			s.publishDiagnostics(ctx, docURI, content, 0)
 		}
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -132,6 +132,7 @@ func TestServer_Initialized_NonBlocking(t *testing.T) {
 
 func TestServer_RegisterFileWatchers_IncludesPricesPattern(t *testing.T) {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -613,6 +614,7 @@ func TestIsFullChange(t *testing.T) {
 
 func TestServer_PublishDiagnostics_ParseError(t *testing.T) {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -639,6 +641,7 @@ func TestServer_PublishDiagnostics_ParseError(t *testing.T) {
 
 func TestServer_PublishDiagnostics_ParseError_RangeSpansToken(t *testing.T) {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -681,6 +684,7 @@ func TestServer_PublishDiagnostics_ParseError_RangeSpansToken(t *testing.T) {
 
 func TestServer_PublishDiagnostics_BalanceError(t *testing.T) {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -717,6 +721,7 @@ func TestServer_PublishDiagnostics_BalanceError(t *testing.T) {
 
 func TestServer_PublishDiagnostics_NoErrors(t *testing.T) {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -787,6 +792,7 @@ func TestServer_GetDocument_NotFound(t *testing.T) {
 
 func TestServer_GetResolved_Found(t *testing.T) {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -875,6 +881,7 @@ include transactions.journal`
 	require.NoError(t, err)
 
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -1034,6 +1041,7 @@ func TestUriToPath(t *testing.T) {
 
 func TestServer_DidOpen_NonFileURI(t *testing.T) {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -1081,6 +1089,7 @@ include 2025.journal`
 	require.NoError(t, err)
 
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := &mockClient{}
 	srv.SetClient(client)
 
@@ -1213,6 +1222,7 @@ func TestServer_DiagnosticsSettings(t *testing.T) {
 	t.Run("undeclared accounts disabled", func(t *testing.T) {
 		client := &mockClient{}
 		srv := NewServer()
+		srv.diagDebounce = 0
 		srv.SetClient(client)
 
 		settings := srv.getSettings()
@@ -1246,6 +1256,7 @@ func TestServer_DiagnosticsSettings(t *testing.T) {
 	t.Run("undeclared commodities disabled", func(t *testing.T) {
 		client := &mockClient{}
 		srv := NewServer()
+		srv.diagDebounce = 0
 		srv.SetClient(client)
 
 		settings := srv.getSettings()
@@ -1279,6 +1290,7 @@ func TestServer_DiagnosticsSettings(t *testing.T) {
 	t.Run("unbalanced transactions disabled", func(t *testing.T) {
 		client := &mockClient{}
 		srv := NewServer()
+		srv.diagDebounce = 0
 		srv.SetClient(client)
 
 		settings := srv.getSettings()
@@ -1314,6 +1326,7 @@ func TestServer_BalanceTolerance(t *testing.T) {
 	t.Run("imbalance within user tolerance is not reported", func(t *testing.T) {
 		client := &mockClient{}
 		srv := NewServer()
+		srv.diagDebounce = 0
 		srv.SetClient(client)
 
 		settings := srv.getSettings()
@@ -1346,6 +1359,7 @@ func TestServer_BalanceTolerance(t *testing.T) {
 	t.Run("imbalance exceeding user tolerance is reported", func(t *testing.T) {
 		client := &mockClient{}
 		srv := NewServer()
+		srv.diagDebounce = 0
 		srv.SetClient(client)
 
 		settings := srv.getSettings()

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -104,6 +104,7 @@ type testServer struct {
 
 func newTestServer() *testServer {
 	srv := NewServer()
+	srv.diagDebounce = 0
 	client := newIntegrationMockClient()
 	srv.SetClient(client)
 	return &testServer{


### PR DESCRIPTION
Closes #34

## Problem

Every `DidOpen`/`DidChange` spawned an uncoordinated `go publishDiagnostics(...)` — no debounce, no cancellation, no document version. Rapid typing queued N parallel parses and a stale computation could overwrite newer diagnostics.

## Fix

- **Trailing debounce (100ms) per URI** — rapid edits coalesce into a single diagnostics publish.
- **`context.WithCancel` per URI** — a superseded computation is cancelled before it publishes; `ctx.Err()` is checked after the expensive parse/analyze step.
- **Document version propagation** — `PublishDiagnosticsParams.Version` carries the client's document version so editors can drop out-of-order results.
- **`DidClose` cancels pending work** — closing a document stops any in-flight diagnostics for that URI.

## Verification

5 new concurrency tests (`diagnostics_debounce_test.go`):
- `RapidEditsCoalesce` — 11 edits → exactly 1 publish
- `SupersededComputationNeverPublishes` — stale version never appears
- `PublishedVersionMatchesDocument` — version round-trips correctly
- `DidCloseCancelsPending` — no publish after close
- `IndependentURIsDoNotInterfere` — per-URI isolation

Full suite: `go test -race ./...` ✅, `golangci-lint run` ✅