### PR TITLE
ci: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,19 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.6
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - name: Run tests with coverage
@@ -38,8 +38,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 
@@ -28,7 +28,7 @@ jobs:
           echo "${{ secrets.MINISIGN_PRIVATE_KEY }}" | base64 -d > /tmp/minisign.key
           chmod 600 /tmp/minisign.key
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
Closes #52

## Summary

GitHub Actions runners deprecate Node.js 20. All Node-based actions in `ci.yml` and `release.yml` are upgraded to versions targeting Node.js 24.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v5 |
| `actions/setup-go` | v5 | v6 |
| `golangci/golangci-lint-action` | v8 | v9 |
| `goreleaser/goreleaser-action` | v6 | v7 |

`vladopajic/go-test-coverage@v2` uses Docker, not Node — no change needed.

## Verification

The CI workflow on this PR will exercise `checkout`, `setup-go`, and `golangci-lint-action`. The Release workflow (`goreleaser-action`) will only run on the next tag push, but the action version is confirmed to use `node24` via its `action.yml`.