### PR TITLE
feat(server): make diagnostics actionable

### DIFF
--- a/internal/server/code_action.go
+++ b/internal/server/code_action.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/shopspring/decimal"
 	"go.lsp.dev/protocol"
@@ -12,6 +14,7 @@ import (
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/filetype"
 	"github.com/juev/hledger-lsp/internal/formatter"
+	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/lsputil"
 	"github.com/juev/hledger-lsp/internal/parser"
 )
@@ -67,32 +70,64 @@ func (s *Server) getQuickFixCodeActions(params *protocol.CodeActionParams) []pro
 	actions := make([]protocol.CodeAction, 0, len(diagnostics))
 	mapper := lsputil.NewPositionMapper(doc)
 	for _, diag := range diagnostics {
-		journal, _ := parser.Parse(doc)
-		if journal == nil {
+		var action protocol.CodeAction
+		switch fmt.Sprint(diag.Code) {
+		case "UNBALANCED":
+			journal, _ := parser.Parse(doc)
+			if journal == nil {
+				continue
+			}
+			formats := commodityFormats
+			if formats == nil {
+				formats = formatter.ExtractCommodityFormats(journal.Directives)
+			}
+			var ok bool
+			action, ok = s.quickFixForUnbalanced(params.TextDocument.URI, doc, mapper, journal, formats, settings.Diagnostics.BalanceTolerance, diag)
+			if !ok {
+				continue
+			}
+		case "UNDECLARED_ACCOUNT":
+			var ok bool
+			action, ok = s.quickFixForUndeclaredAccount(params.TextDocument.URI, diag)
+			if !ok {
+				continue
+			}
+		case "UNDECLARED_COMMODITY":
+			var ok bool
+			action, ok = s.quickFixForUndeclaredCommodity(params.TextDocument.URI, diag)
+			if !ok {
+				continue
+			}
+		default:
 			continue
 		}
-		formats := commodityFormats
-		if formats == nil {
-			formats = formatter.ExtractCommodityFormats(journal.Directives)
-		}
-		action, ok := s.quickFixForUnbalanced(params.TextDocument.URI, doc, mapper, journal, formats, settings.Diagnostics.BalanceTolerance, diag)
-		if ok {
-			actions = append(actions, action)
-		}
+		actions = append(actions, action)
 	}
+
+	// Preferred quickfixes first (the single correct amount fix) so the editor
+	// surfaces the best action when several quickfixes are available.
+	sort.SliceStable(actions, func(i, j int) bool {
+		return actions[i].IsPreferred && !actions[j].IsPreferred
+	})
 
 	return actions
 }
 
 func (s *Server) quickFixDiagnostics(params *protocol.CodeActionParams, doc string) []protocol.Diagnostic {
 	if len(params.Context.Diagnostics) > 0 {
-		return params.Context.Diagnostics
+		filtered := make([]protocol.Diagnostic, 0, len(params.Context.Diagnostics))
+		for _, diag := range params.Context.Diagnostics {
+			if isQuickFixableCode(fmt.Sprint(diag.Code)) {
+				filtered = append(filtered, diag)
+			}
+		}
+		return filtered
 	}
 
 	diagnostics := s.analyze(uriToPath(params.TextDocument.URI), doc)
 	filtered := make([]protocol.Diagnostic, 0, len(diagnostics))
 	for _, diag := range diagnostics {
-		if fmt.Sprint(diag.Code) != "UNBALANCED" {
+		if !isQuickFixableCode(fmt.Sprint(diag.Code)) {
 			continue
 		}
 		if rangesOverlap(diag.Range, params.Range) {
@@ -100,6 +135,14 @@ func (s *Server) quickFixDiagnostics(params *protocol.CodeActionParams, doc stri
 		}
 	}
 	return filtered
+}
+
+func isQuickFixableCode(code string) bool {
+	switch code {
+	case "UNBALANCED", "UNDECLARED_ACCOUNT", "UNDECLARED_COMMODITY":
+		return true
+	}
+	return false
 }
 
 func (s *Server) quickFixForUnbalanced(
@@ -120,9 +163,33 @@ func (s *Server) quickFixForUnbalanced(
 		return protocol.CodeAction{}, false
 	}
 
+	edit, title, ok := buildUnbalancedFix(uri, doc, mapper, commodityFormats, balanceTolerance, tx)
+	if !ok {
+		return protocol.CodeAction{}, false
+	}
+	return protocol.CodeAction{
+		Title:       title,
+		Kind:        protocol.QuickFix,
+		Diagnostics: []protocol.Diagnostic{diag},
+		IsPreferred: true,
+		Edit:        edit,
+	}, true
+}
+
+// buildUnbalancedFix computes the WorkspaceEdit that corrects the final real
+// posting of a single-commodity unbalanced transaction. Shared by the
+// UNBALANCED quickfix and the hledger.fixUnbalanced code-lens command.
+func buildUnbalancedFix(
+	uri protocol.DocumentURI,
+	doc string,
+	mapper *lsputil.PositionMapper,
+	commodityFormats map[string]formatter.CommodityFormat,
+	balanceTolerance float64,
+	tx *ast.Transaction,
+) (*protocol.WorkspaceEdit, string, bool) {
 	result := analyzer.CheckBalance(tx, decimal.NewFromFloat(balanceTolerance))
 	if result.Balanced || result.InferredIdx >= 0 || len(result.Differences) != 1 {
-		return protocol.CodeAction{}, false
+		return nil, "", false
 	}
 
 	var commodity string
@@ -131,12 +198,12 @@ func (s *Server) quickFixForUnbalanced(
 	}
 	signedSum := signedCommoditySum(tx, commodity)
 	if commodity == "" || signedSum.IsZero() {
-		return protocol.CodeAction{}, false
+		return nil, "", false
 	}
 
 	postingIndex := findLastFixableRealPosting(tx, commodity)
 	if postingIndex < 0 {
-		return protocol.CodeAction{}, false
+		return nil, "", false
 	}
 
 	posting := &tx.Postings[postingIndex]
@@ -146,21 +213,15 @@ func (s *Server) quickFixForUnbalanced(
 
 	lineEdit, ok := buildQuickFixEdit(doc, mapper, tx, postingIndex, &newAmount, commodityFormats)
 	if !ok {
-		return protocol.CodeAction{}, false
+		return nil, "", false
 	}
 
 	title := fmt.Sprintf("Fix final posting amount to %s", formatter.FormatAmount(&newAmount, commodityFormats))
-	return protocol.CodeAction{
-		Title:       title,
-		Kind:        protocol.QuickFix,
-		Diagnostics: []protocol.Diagnostic{diag},
-		IsPreferred: true,
-		Edit: &protocol.WorkspaceEdit{
-			Changes: map[protocol.DocumentURI][]protocol.TextEdit{
-				uri: {lineEdit},
-			},
+	return &protocol.WorkspaceEdit{
+		Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+			uri: {lineEdit},
 		},
-	}, true
+	}, title, true
 }
 
 func (s *Server) getCodeActions(uri protocol.DocumentURI) []protocol.CodeAction {
@@ -194,10 +255,17 @@ func (s *Server) getCodeActions(uri protocol.DocumentURI) []protocol.CodeAction 
 }
 
 func (s *Server) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCommandParams) (any, error) {
-	if params.Command != "hledger.run" {
+	switch params.Command {
+	case "hledger.run":
+		return s.executeRunCommand(ctx, params)
+	case "hledger.fixUnbalanced":
+		return s.executeFixUnbalanced(ctx, params)
+	default:
 		return nil, fmt.Errorf("unknown command: %s", params.Command)
 	}
+}
 
+func (s *Server) executeRunCommand(ctx context.Context, params *protocol.ExecuteCommandParams) (any, error) {
 	if len(params.Arguments) < 1 {
 		return nil, fmt.Errorf("missing command argument")
 	}
@@ -222,6 +290,141 @@ func (s *Server) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCom
 	}
 
 	return formatOutputAsComment(cmd, output), nil
+}
+
+// executeFixUnbalanced resolves the transaction targeted by the unbalanced
+// code lens and applies the balance quickfix via
+// workspace/applyEdit so clicking the lens fixes the transaction in place.
+func (s *Server) executeFixUnbalanced(ctx context.Context, params *protocol.ExecuteCommandParams) (any, error) {
+	if len(params.Arguments) < 2 {
+		return nil, fmt.Errorf("missing arguments")
+	}
+
+	uriRaw, ok := params.Arguments[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid uri argument")
+	}
+	uri := protocol.DocumentURI(uriRaw)
+
+	txRange, ok := commandRangeArg(params.Arguments[1])
+	if !ok {
+		return nil, fmt.Errorf("invalid transaction range argument")
+	}
+
+	doc, ok := s.getJournalDoc(uri)
+	if !ok {
+		return nil, fmt.Errorf("document not open")
+	}
+	journal, _ := parser.Parse(doc)
+	if journal == nil {
+		return nil, fmt.Errorf("failed to parse document")
+	}
+
+	tx := findTransactionByRange(journal.Transactions, txRange)
+	if tx == nil {
+		return nil, fmt.Errorf("transaction not found")
+	}
+
+	settings := s.getSettings()
+	var commodityFormats map[string]formatter.CommodityFormat
+	if s.workspace != nil {
+		commodityFormats = s.workspace.GetCommodityFormatsForFile(uriToPath(uri))
+	}
+	if commodityFormats == nil {
+		commodityFormats = formatter.ExtractCommodityFormats(journal.Directives)
+	}
+
+	edit, _, ok := buildUnbalancedFix(uri, doc, lsputil.NewPositionMapper(doc), commodityFormats, settings.Diagnostics.BalanceTolerance, tx)
+	if !ok {
+		return nil, fmt.Errorf("no balance fix available")
+	}
+
+	if s.client == nil {
+		return edit, nil
+	}
+
+	applied, err := s.client.ApplyEdit(ctx, &protocol.ApplyWorkspaceEditParams{
+		Label: "hledger-lsp: fix unbalanced transaction",
+		Edit:  *edit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("apply workspace edit: %w", err)
+	}
+	if !applied {
+		return nil, fmt.Errorf("client rejected the edit")
+	}
+	return nil, nil
+}
+
+func findTransactionByRange(transactions []ast.Transaction, target protocol.Range) *ast.Transaction {
+	for i := range transactions {
+		r := astRangeToProtocol(transactions[i].Range)
+		if r != nil && *r == target {
+			return &transactions[i]
+		}
+	}
+	return nil
+}
+
+func commandRangeArg(v any) (protocol.Range, bool) {
+	switch value := v.(type) {
+	case protocol.Range:
+		return value, true
+	case *protocol.Range:
+		if value != nil {
+			return *value, true
+		}
+		return protocol.Range{}, false
+	case map[string]any:
+		start, startOK := commandPositionArg(value["start"])
+		end, endOK := commandPositionArg(value["end"])
+		return protocol.Range{Start: start, End: end}, startOK && endOK
+	default:
+		return protocol.Range{}, false
+	}
+}
+
+func commandPositionArg(v any) (protocol.Position, bool) {
+	value, ok := v.(map[string]any)
+	if !ok {
+		return protocol.Position{}, false
+	}
+	line, lineOK := argUint32(value["line"])
+	character, characterOK := argUint32(value["character"])
+	return protocol.Position{Line: line, Character: character}, lineOK && characterOK
+}
+
+func argUint32(v any) (uint32, bool) {
+	switch n := v.(type) {
+	case float64:
+		if n < 0 || n > float64(^uint32(0)) || n != float64(uint32(n)) {
+			return 0, false
+		}
+		return uint32(n), true
+	case float32:
+		if n < 0 || float64(n) > float64(^uint32(0)) || n != float32(uint32(n)) {
+			return 0, false
+		}
+		return uint32(n), true
+	case int:
+		if n < 0 || uint64(n) > uint64(^uint32(0)) {
+			return 0, false
+		}
+		return uint32(n), true
+	case int64:
+		if n < 0 || uint64(n) > uint64(^uint32(0)) {
+			return 0, false
+		}
+		return uint32(n), true
+	case uint32:
+		return n, true
+	case uint64:
+		if n > uint64(^uint32(0)) {
+			return 0, false
+		}
+		return uint32(n), true
+	}
+	return 0, false
 }
 
 // resolveCommandFile determines which journal file an hledger.run command
@@ -357,4 +560,171 @@ func adjustedRawQuantity(raw string, quantity decimal.Decimal) string {
 	}
 
 	return formatter.FormatNumber(quantity, format)
+}
+
+// directiveKind distinguishes account vs commodity declarations so the
+// insertion-selection heuristic can match directives of the same kind.
+type directiveKind int
+
+const (
+	kindAccount directiveKind = iota
+	kindCommodity
+)
+
+// declarationTarget identifies the file and position where a new directive
+// should be inserted.
+type declarationTarget struct {
+	URI      protocol.DocumentURI
+	Position protocol.Position
+}
+
+func (s *Server) quickFixForUndeclaredAccount(uri protocol.DocumentURI, diag protocol.Diagnostic) (protocol.CodeAction, bool) {
+	name, ok := extractQuotedName(diag.Message, "account '", "' is not declared")
+	if !ok || name == "" {
+		return protocol.CodeAction{}, false
+	}
+	target := selectDeclarationInsertion(s.declarationResolved(uri), uri, kindAccount)
+	return protocol.CodeAction{
+		Title:       "Declare account " + name,
+		Kind:        protocol.QuickFix,
+		Diagnostics: []protocol.Diagnostic{diag},
+		Edit:        declarationEdit(target.URI, target.Position, declarationDirectiveText(target.Position, "account "+name)),
+	}, true
+}
+
+func (s *Server) quickFixForUndeclaredCommodity(uri protocol.DocumentURI, diag protocol.Diagnostic) (protocol.CodeAction, bool) {
+	symbol, ok := extractQuotedName(diag.Message, "commodity '", "' has no directive")
+	if !ok || symbol == "" {
+		return protocol.CodeAction{}, false
+	}
+	target := selectDeclarationInsertion(s.declarationResolved(uri), uri, kindCommodity)
+	return protocol.CodeAction{
+		Title:       "Declare commodity " + symbol,
+		Kind:        protocol.QuickFix,
+		Diagnostics: []protocol.Diagnostic{diag},
+		Edit:        declarationEdit(target.URI, target.Position, declarationDirectiveText(target.Position, formatCommodityDirectiveText(symbol))),
+	}, true
+}
+
+func declarationEdit(uri protocol.DocumentURI, pos protocol.Position, text string) *protocol.WorkspaceEdit {
+	return &protocol.WorkspaceEdit{
+		Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+			uri: {{
+				Range:   protocol.Range{Start: pos, End: pos},
+				NewText: text,
+			}},
+		},
+	}
+}
+
+func (s *Server) declarationResolved(uri protocol.DocumentURI) *include.ResolvedJournal {
+	if resolved := s.GetResolved(uri); resolved != nil {
+		return resolved
+	}
+	return s.getWorkspaceResolved(uri)
+}
+
+// selectDeclarationInsertion chooses the file and position for a new directive
+// of the given kind. The open document is the primary journal in the resolved
+// tree, so it wins when it already declares the same kind; otherwise the first
+// included file with same-kind declarations is chosen; otherwise the directive
+// is inserted at the top of the current file.
+func selectDeclarationInsertion(resolved *include.ResolvedJournal, currentURI protocol.DocumentURI, kind directiveKind) declarationTarget {
+	if resolved == nil || resolved.Primary == nil {
+		return declarationTarget{URI: currentURI}
+	}
+	if pos, ok := lastDirectiveEndPosition(resolved.Primary, kind); ok {
+		return declarationTarget{URI: currentURI, Position: pos}
+	}
+	for _, path := range resolved.FileOrder {
+		journal, ok := resolved.Files[path]
+		if !ok {
+			continue
+		}
+		if pos, ok := lastDirectiveEndPosition(journal, kind); ok {
+			return declarationTarget{URI: pathToURI(path), Position: pos}
+		}
+	}
+	return declarationTarget{URI: currentURI}
+}
+
+// lastDirectiveEndPosition returns the exclusive end position of the last
+// matching directive, converted from the parser's 1-based coordinates to LSP.
+func lastDirectiveEndPosition(journal *ast.Journal, kind directiveKind) (protocol.Position, bool) {
+	var last ast.Directive
+	for _, d := range journal.Directives {
+		var match bool
+		switch kind {
+		case kindAccount:
+			_, match = d.(ast.AccountDirective)
+		case kindCommodity:
+			_, match = d.(ast.CommodityDirective)
+		}
+		if !match {
+			continue
+		}
+		last = d
+	}
+	if last == nil {
+		return protocol.Position{}, false
+	}
+	end := last.GetRange().End
+	return protocol.Position{
+		Line:      uint32(max(0, end.Line-1)),
+		Character: uint32(max(0, end.Column-1)),
+	}, true
+}
+
+func declarationDirectiveText(position protocol.Position, directive string) string {
+	if position.Character > 0 {
+		return "\n" + directive + "\n"
+	}
+	return directive + "\n"
+}
+
+// formatCommodityDirectiveText emits a valid `commodity` directive for the
+// symbol. Bare symbols follow the lexer rules; symbols with spaces or other
+// special characters are double-quoted.
+func formatCommodityDirectiveText(symbol string) string {
+	if commodityNeedsQuotes(symbol) {
+		symbol = `"` + symbol + `"`
+	}
+	return "commodity " + symbol
+}
+
+func commodityNeedsQuotes(symbol string) bool {
+	runes := []rune(symbol)
+	if len(runes) == 0 {
+		return true
+	}
+	if len(runes) == 1 && unicode.Is(unicode.Sc, runes[0]) {
+		return false
+	}
+	if len(runes) == 3 && runes[0] >= 'A' && runes[0] <= 'Z' && runes[1] >= 'A' && runes[1] <= 'Z' && unicode.Is(unicode.Sc, runes[2]) {
+		return false
+	}
+	if !unicode.IsLetter(runes[0]) {
+		return true
+	}
+	for _, r := range runes {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractQuotedName accepts only the owned diagnostic shape and returns its
+// single-quoted payload. Account names and commodity symbols never contain a
+// single quote.
+func extractQuotedName(msg, prefix, suffix string) (string, bool) {
+	name, ok := strings.CutPrefix(msg, prefix)
+	if !ok {
+		return "", false
+	}
+	name, ok = strings.CutSuffix(name, suffix)
+	if !ok || name == "" || strings.ContainsAny(name, "'\r\n") {
+		return "", false
+	}
+	return name, true
 }

--- a/internal/server/code_action_declarations_test.go
+++ b/internal/server/code_action_declarations_test.go
@@ -1,0 +1,355 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/ast"
+	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/workspace"
+)
+
+func accountDirectiveAt(line int) ast.AccountDirective {
+	return ast.AccountDirective{Range: ast.Range{
+		Start: ast.Position{Line: line},
+		End:   ast.Position{Line: line + 1, Column: 1},
+	}}
+}
+
+func commodityDirectiveAt(line int) ast.CommodityDirective {
+	return ast.CommodityDirective{Range: ast.Range{
+		Start: ast.Position{Line: line},
+		End:   ast.Position{Line: line + 1, Column: 1},
+	}}
+}
+
+func TestSelectDeclarationInsertion_PrimaryAppendsAfterLastAccountDirective(t *testing.T) {
+	primary := &ast.Journal{Directives: []ast.Directive{
+		accountDirectiveAt(1),
+		accountDirectiveAt(3),
+	}}
+	resolved := include.NewResolvedJournal(primary)
+
+	target := selectDeclarationInsertion(resolved, "file:///main.journal", kindAccount)
+	assert.Equal(t, protocol.DocumentURI("file:///main.journal"), target.URI)
+	assert.Equal(t, uint32(3), target.Position.Line, "after the last account directive")
+	assert.Equal(t, uint32(0), target.Position.Character)
+}
+
+func TestSelectDeclarationInsertion_FallsBackToIncludedFile(t *testing.T) {
+	primary := &ast.Journal{} // no account directives (only an include)
+	included := &ast.Journal{Directives: []ast.Directive{
+		accountDirectiveAt(5), // 1-based line 5
+	}}
+	incPath := "/tmp/inc.journal"
+	resolved := &include.ResolvedJournal{
+		Primary:   primary,
+		Files:     map[string]*ast.Journal{incPath: included},
+		FileOrder: []string{incPath},
+	}
+
+	target := selectDeclarationInsertion(resolved, "file:///main.journal", kindAccount)
+	assert.Equal(t, pathToURI(incPath), target.URI)
+	assert.Equal(t, uint32(5), target.Position.Line, "after the included account directive")
+}
+
+func TestSelectDeclarationInsertion_NoDeclarationsAnywhere(t *testing.T) {
+	primary := &ast.Journal{}
+	resolved := include.NewResolvedJournal(primary)
+
+	target := selectDeclarationInsertion(resolved, "file:///main.journal", kindAccount)
+	assert.Equal(t, protocol.DocumentURI("file:///main.journal"), target.URI)
+	assert.Equal(t, uint32(0), target.Position.Line)
+	assert.Equal(t, uint32(0), target.Position.Character)
+}
+
+func TestSelectDeclarationInsertion_NilResolved(t *testing.T) {
+	target := selectDeclarationInsertion(nil, "file:///main.journal", kindAccount)
+	assert.Equal(t, protocol.DocumentURI("file:///main.journal"), target.URI)
+	assert.Equal(t, uint32(0), target.Position.Line)
+}
+
+func TestSelectDeclarationInsertion_KindCommodityMatchesCommodityDirective(t *testing.T) {
+	primary := &ast.Journal{Directives: []ast.Directive{
+		accountDirectiveAt(2),   // account directive — must be skipped for commodity
+		commodityDirectiveAt(4), // 1-based line 4
+	}}
+	resolved := include.NewResolvedJournal(primary)
+
+	target := selectDeclarationInsertion(resolved, "file:///main.journal", kindCommodity)
+	assert.Equal(t, protocol.DocumentURI("file:///main.journal"), target.URI)
+	assert.Equal(t, uint32(4), target.Position.Line, "after the commodity directive, skipping account directive")
+}
+
+func TestFormatCommodityDirectiveText(t *testing.T) {
+	cases := []struct {
+		name   string
+		symbol string
+		want   string
+	}{
+		{"single rune bare", "$", "commodity $"},
+		{"euro bare", "€", "commodity €"},
+		{"bare ticker", "EUR", "commodity EUR"},
+		{"numeric symbol quoted", "123", "commodity \"123\""},
+		{"digit prefix quoted", "123USD", "commodity \"123USD\""},
+		{"with space quoted", "TEST B", "commodity \"TEST B\""},
+		{"with dot quoted", "TEST.A", "commodity \"TEST.A\""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatCommodityDirectiveText(tc.symbol))
+		})
+	}
+}
+
+func TestExtractQuotedName_RequiresOwnedDiagnosticFormat(t *testing.T) {
+	name, ok := extractQuotedName("account 'custom:thing' is not declared", "account '", "' is not declared")
+	require.True(t, ok)
+	assert.Equal(t, "custom:thing", name)
+
+	_, ok = extractQuotedName("account 'custom:thing' is not declared\ninclude secrets.journal", "account '", "' is not declared")
+	assert.False(t, ok)
+}
+
+func TestServer_CodeAction_DeclareAccountQuickFix(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+
+	uri := protocol.DocumentURI("file:///test.journal")
+	content := `account assets:cash
+
+2024-01-15 grocery
+    custom:thing  $50
+    assets:cash`
+
+	diagnostics, err := ts.openAndWait(uri, content)
+	require.NoError(t, err)
+
+	diag := requireDiagnosticByCode(t, diagnostics, "UNDECLARED_ACCOUNT")
+	actions, err := codeActionsForDiagnostics(ts, uri, []protocol.Diagnostic{diag})
+	require.NoError(t, err)
+
+	action := requireQuickFixAction(t, actions)
+	assert.Contains(t, action.Title, "Declare account custom:thing")
+
+	fixed := applyWorkspaceEditToContent(t, content, uri, action.Edit)
+	assert.Equal(t, `account assets:cash
+account custom:thing
+
+2024-01-15 grocery
+    custom:thing  $50
+    assets:cash`, fixed)
+
+	// After applying, the account is declared — no UNDECLARED_ACCOUNT diagnostic.
+	diagnostics, err = ts.replaceAndWait(uri, fixed)
+	require.NoError(t, err)
+	_, err = findDiagnosticByCode(diagnostics, "UNDECLARED_ACCOUNT")
+	assert.Error(t, err)
+}
+
+func TestServer_CodeAction_DeclareCommodityQuickFix(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+
+	uri := protocol.DocumentURI("file:///test.journal")
+	content := `commodity EUR
+
+2024-01-15 grocery
+    assets:cash  50 "TEST B"
+    equity:open`
+
+	diagnostics, err := ts.openAndWait(uri, content)
+	require.NoError(t, err)
+
+	diag := requireDiagnosticByCode(t, diagnostics, "UNDECLARED_COMMODITY")
+	actions, err := codeActionsForDiagnostics(ts, uri, []protocol.Diagnostic{diag})
+	require.NoError(t, err)
+
+	action := requireQuickFixAction(t, actions)
+	assert.Contains(t, action.Title, "Declare commodity TEST B")
+
+	fixed := applyWorkspaceEditToContent(t, content, uri, action.Edit)
+	assert.Equal(t, `commodity EUR
+commodity "TEST B"
+
+2024-01-15 grocery
+    assets:cash  50 "TEST B"
+    equity:open`, fixed)
+
+	diagnostics, err = ts.replaceAndWait(uri, fixed)
+	require.NoError(t, err)
+	_, err = findDiagnosticByCode(diagnostics, "UNDECLARED_COMMODITY")
+	assert.Error(t, err)
+}
+
+func TestServer_CodeAction_DeclareAccount_CJKName(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+
+	uri := protocol.DocumentURI("file:///test.journal")
+	content := `account assets:cash
+
+2024-01-15 покупка
+    расходы:еда  $50
+    assets:cash`
+
+	diagnostics, err := ts.openAndWait(uri, content)
+	require.NoError(t, err)
+
+	diag := requireDiagnosticByCode(t, diagnostics, "UNDECLARED_ACCOUNT")
+	assert.Contains(t, diag.Message, "расходы:еда")
+
+	actions, err := codeActionsForDiagnostics(ts, uri, []protocol.Diagnostic{diag})
+	require.NoError(t, err)
+
+	action := requireQuickFixAction(t, actions)
+	fixed := applyWorkspaceEditToContent(t, content, uri, action.Edit)
+	assert.Equal(t, `account assets:cash
+account расходы:еда
+
+2024-01-15 покупка
+    расходы:еда  $50
+    assets:cash`, fixed)
+}
+
+func TestServer_CodeAction_DeclareAccount_CRLF(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+
+	uri := protocol.DocumentURI("file:///test.journal")
+	content := "account assets:cash\r\n\r\n2024-01-15 grocery\r\n    custom:thing  $50\r\n    assets:cash"
+
+	diagnostics, err := ts.openAndWait(uri, content)
+	require.NoError(t, err)
+
+	diag := requireDiagnosticByCode(t, diagnostics, "UNDECLARED_ACCOUNT")
+	actions, err := codeActionsForDiagnostics(ts, uri, []protocol.Diagnostic{diag})
+	require.NoError(t, err)
+
+	action := requireQuickFixAction(t, actions)
+	// The server normalizes ingestion to LF; the edit is against the
+	// normalized document, so the applied result uses LF.
+	normalized := "account assets:cash\n\n2024-01-15 grocery\n    custom:thing  $50\n    assets:cash"
+	fixed := applyWorkspaceEditToContent(t, normalized, uri, action.Edit)
+	assert.Equal(t, "account assets:cash\naccount custom:thing\n\n2024-01-15 grocery\n    custom:thing  $50\n    assets:cash", fixed)
+}
+
+func TestServer_CodeAction_DeclareAccount_TargetsIncludedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	accountsPath := filepath.Join(tmpDir, "accounts.journal")
+	mainPath := filepath.Join(tmpDir, "main.journal")
+	accountsContent := "account assets:cash\n"
+	mainContent := `include accounts.journal
+
+2024-01-15 grocery
+    custom:thing  $50
+    assets:cash`
+
+	require.NoError(t, os.WriteFile(accountsPath, []byte(accountsContent), 0o644))
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainContent), 0o644))
+
+	ts := newTestServer()
+	ts.cliClient = nil
+	loader := include.NewLoader()
+	ts.loader = loader
+	ts.workspace = workspace.NewWorkspace(tmpDir, loader)
+	require.NoError(t, ts.workspace.Initialize())
+	mainURI := pathToURI(mainPath)
+	diagnostics, err := ts.openAndWait(mainURI, mainContent)
+	require.NoError(t, err)
+
+	diag := requireDiagnosticByCode(t, diagnostics, "UNDECLARED_ACCOUNT")
+	actions, err := codeActionsForDiagnostics(ts, mainURI, []protocol.Diagnostic{diag})
+	require.NoError(t, err)
+
+	action := requireQuickFixAction(t, actions)
+	accountsURI := pathToURI(accountsPath)
+	fixed := applyWorkspaceEditToContent(t, accountsContent, accountsURI, action.Edit)
+	assert.Equal(t, "account assets:cash\naccount custom:thing\n", fixed)
+	assert.NotContains(t, action.Edit.Changes, mainURI)
+}
+
+func TestServer_CodeAction_DeclareAccount_PrefersOpenIncludedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainPath := filepath.Join(tmpDir, "main.journal")
+	includedPath := filepath.Join(tmpDir, "included.journal")
+	mainContent := "include included.journal\n\naccount assets:root\n"
+	includedContent := `account assets:cash
+
+2024-01-15 grocery
+    custom:thing  $50
+    assets:cash`
+
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainContent), 0o644))
+	require.NoError(t, os.WriteFile(includedPath, []byte(includedContent), 0o644))
+
+	ts := newTestServer()
+	ts.cliClient = nil
+	loader := include.NewLoader()
+	ts.loader = loader
+	ts.workspace = workspace.NewWorkspace(tmpDir, loader)
+	require.NoError(t, ts.workspace.Initialize())
+	workspaceResolved := ts.workspace.GetResolvedForFile(includedPath)
+	require.NotNil(t, workspaceResolved)
+	rootDeclaration := workspaceResolved.Primary.Directives[0].(ast.AccountDirective)
+	assert.Equal(t, "assets:root", rootDeclaration.Account.Name)
+	includedURI := pathToURI(includedPath)
+	diagnostics, err := ts.openAndWait(includedURI, includedContent)
+	require.NoError(t, err)
+	workspaceResolved = ts.workspace.GetResolvedForFile(includedPath)
+	rootDeclaration = workspaceResolved.Primary.Directives[0].(ast.AccountDirective)
+	assert.Equal(t, "assets:root", rootDeclaration.Account.Name)
+
+	diag := requireDiagnosticByCode(t, diagnostics, "UNDECLARED_ACCOUNT")
+	actions, err := codeActionsForDiagnostics(ts, includedURI, []protocol.Diagnostic{diag})
+	require.NoError(t, err)
+
+	action := requireQuickFixAction(t, actions)
+	fixed := applyWorkspaceEditToContent(t, includedContent, includedURI, action.Edit)
+	assert.Contains(t, fixed, "account assets:cash\naccount custom:thing\n")
+	assert.NotContains(t, action.Edit.Changes, pathToURI(mainPath))
+}
+
+// TestServer_QuickFix_DeclareAccount_TargetsIncludedFile drives the quickfix
+// builder directly with a constructed include tree. The analyzer only flags
+// undeclared accounts when at least one `account` directive exists (opt-in), so
+// an end-to-end "declarations live in an included file" path requires a
+// workspace; testing the builder isolates the multi-file targeting logic.
+func TestServer_QuickFix_DeclareAccount_TargetsIncludedFile(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+
+	uri := protocol.DocumentURI("file:///main.journal")
+	// Primary (the open document) declares no accounts; the included file does.
+	primary := &ast.Journal{}
+	included := &ast.Journal{Directives: []ast.Directive{accountDirectiveAt(2)}}
+	incPath := "/tmp/accounts.journal"
+	ts.resolved.Store(uri, &include.ResolvedJournal{
+		Primary:   primary,
+		Files:     map[string]*ast.Journal{incPath: included},
+		FileOrder: []string{incPath},
+	})
+
+	diag := protocol.Diagnostic{
+		Code:    "UNDECLARED_ACCOUNT",
+		Message: "account 'custom:thing' is not declared",
+	}
+	action, ok := ts.quickFixForUndeclaredAccount(uri, diag)
+	require.True(t, ok)
+
+	accountsURI := pathToURI(incPath)
+	changes, ok := action.Edit.Changes[accountsURI]
+	require.True(t, ok, "quickfix should target the included accounts.journal")
+	require.Len(t, changes, 1)
+	assert.Equal(t, "account custom:thing\n", changes[0].NewText)
+	assert.Equal(t, uint32(2), changes[0].Range.Start.Line, "insert after the existing account directive")
+
+	// The current file must not be edited.
+	_, currentEdited := action.Edit.Changes[uri]
+	assert.False(t, currentEdited, "quickfix must not edit the file that has no declarations")
+}

--- a/internal/server/code_action_quickfix_test.go
+++ b/internal/server/code_action_quickfix_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -529,8 +530,11 @@ skip 1`,
 
 			actions, err := codeActionsForDiagnostics(ts, tt.uri, diagnostics)
 			require.NoError(t, err)
-			_, err = findQuickFixAction(actions)
-			assert.Error(t, err)
+			// These transactions must not offer an UNBALANCED amount quickfix.
+			// Declare-commodity quickfixes may appear (e.g. for an undeclared
+			// `$`), which is legitimate and unrelated to the amount fix.
+			_, err = findQuickFixByDiagnosticCode(actions, "UNBALANCED")
+			assert.Error(t, err, "no UNBALANCED amount quickfix should be offered")
 		})
 	}
 }
@@ -578,6 +582,23 @@ func requireQuickFixAction(t *testing.T, actions []protocol.CodeAction) protocol
 func findQuickFixAction(actions []protocol.CodeAction) (protocol.CodeAction, error) {
 	for _, action := range actions {
 		if action.Kind == protocol.QuickFix {
+			return action, nil
+		}
+	}
+	return protocol.CodeAction{}, assert.AnError
+}
+
+// findQuickFixByDiagnosticCode finds a quickfix whose first attached diagnostic
+// matches the given code, or an error if none.
+func findQuickFixByDiagnosticCode(actions []protocol.CodeAction, code string) (protocol.CodeAction, error) {
+	for _, action := range actions {
+		if action.Kind != protocol.QuickFix {
+			continue
+		}
+		if len(action.Diagnostics) == 0 {
+			continue
+		}
+		if fmt.Sprint(action.Diagnostics[0].Code) == code {
 			return action, nil
 		}
 	}

--- a/internal/server/code_action_test.go
+++ b/internal/server/code_action_test.go
@@ -11,6 +11,7 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/cli"
+	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 // fakeCLIClient is a cliRunner that records the file path it was asked to run
@@ -249,4 +250,37 @@ func TestExecuteCommand_FallbackWithoutURI(t *testing.T) {
 	_, err := s.ExecuteCommand(context.Background(), params)
 	require.NoError(t, err)
 	assert.Equal(t, uriToPath(uriA), fake.lastFile)
+}
+
+func TestExecuteCommand_FixUnbalancedAcceptsJSONRange(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+
+	uri := protocol.DocumentURI("file:///test.journal")
+	content := `2024-01-15 grocery
+    expenses:food  $50
+    assets:cash  $-40`
+
+	_, err := ts.openAndWait(uri, content)
+	require.NoError(t, err)
+	journal, _ := parser.Parse(content)
+	txRange := astRangeToProtocol(journal.Transactions[0].Range)
+
+	_, err = ts.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{
+		Command: "hledger.fixUnbalanced",
+		Arguments: []any{
+			string(uri),
+			map[string]any{
+				"start": map[string]any{"line": float64(txRange.Start.Line), "character": float64(txRange.Start.Character)},
+				"end":   map[string]any{"line": float64(txRange.End.Line), "character": float64(txRange.End.Character)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	applied := ts.client.lastApplyEdit()
+	require.NotNil(t, applied)
+	edits := applied.Edit.Changes[uri]
+	require.Len(t, edits, 1)
+	assert.Contains(t, edits[0].NewText, "$-50")
 }

--- a/internal/server/codelens.go
+++ b/internal/server/codelens.go
@@ -36,10 +36,18 @@ func (s *Server) CodeLens(_ context.Context, params *protocol.CodeLensParams) ([
 		result := analyzer.CheckBalance(tx, decimal.NewFromFloat(settings.Diagnostics.BalanceTolerance))
 
 		title := buildCodeLensTitle(result, len(tx.Postings))
-		lenses = append(lenses, protocol.CodeLens{
+		lens := protocol.CodeLens{
 			Range:   *astRangeToProtocol(tx.Date.Range),
 			Command: &protocol.Command{Title: title},
-		})
+		}
+		if !result.Balanced {
+			// Carry the document URI and the transaction range so
+			// ExecuteCommand can re-resolve the exact transaction and apply the
+			// balance quickfix via workspace/applyEdit.
+			lens.Command.Command = "hledger.fixUnbalanced"
+			lens.Command.Arguments = []any{string(params.TextDocument.URI), *astRangeToProtocol(tx.Range)}
+		}
+		lenses = append(lenses, lens)
 	}
 
 	return lenses, nil

--- a/internal/server/codelens_test.go
+++ b/internal/server/codelens_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func TestCodeLens_BalancedTransaction(t *testing.T) {
@@ -30,6 +32,7 @@ func TestCodeLens_BalancedTransaction(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Contains(t, result[0].Command.Title, "balanced")
+	assert.Empty(t, result[0].Command.Command)
 }
 
 func TestCodeLens_UnbalancedTransaction(t *testing.T) {
@@ -53,6 +56,12 @@ func TestCodeLens_UnbalancedTransaction(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Contains(t, result[0].Command.Title, "unbalanced")
+	assert.Equal(t, "hledger.fixUnbalanced", result[0].Command.Command)
+	journal, _ := parser.Parse(content)
+	require.Equal(t, []any{
+		string(uri),
+		*astRangeToProtocol(journal.Transactions[0].Range),
+	}, result[0].Command.Arguments)
 }
 
 func TestCodeLens_EmptyDocument(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -177,13 +177,20 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 				"source.hledger",
 			},
 		}
-		caps.ExecuteCommandProvider = &protocol.ExecuteCommandOptions{
-			Commands: []string{"hledger.run"},
-		}
 	}
 
 	if settings.Features.CodeLens {
 		caps.CodeLensProvider = &protocol.CodeLensOptions{}
+	}
+	commands := make([]string, 0, 2)
+	if settings.Features.CodeActions {
+		commands = append(commands, "hledger.run")
+	}
+	if settings.Features.CodeLens {
+		commands = append(commands, "hledger.fixUnbalanced")
+	}
+	if len(commands) > 0 {
+		caps.ExecuteCommandProvider = &protocol.ExecuteCommandOptions{Commands: commands}
 	}
 	if settings.Features.InlineCompletion {
 		caps.Experimental = map[string]any{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -208,6 +208,7 @@ func TestServer_Initialize(t *testing.T) {
 	assert.NotNil(t, caps.CodeActionProvider)
 	assert.NotNil(t, caps.ExecuteCommandProvider)
 	assert.Contains(t, caps.ExecuteCommandProvider.Commands, "hledger.run")
+	assert.NotContains(t, caps.ExecuteCommandProvider.Commands, "hledger.fixUnbalanced")
 
 	require.NotNil(t, result.ServerInfo)
 	assert.Equal(t, "hledger-lsp", result.ServerInfo.Name)
@@ -1201,6 +1202,20 @@ func TestServer_Initialize_FeatureToggles(t *testing.T) {
 			checkCaps: func(t *testing.T, caps protocol.ServerCapabilities) {
 				assert.Nil(t, caps.CodeActionProvider)
 				assert.Nil(t, caps.ExecuteCommandProvider)
+			},
+		},
+		{
+			name: "code lens command without code actions",
+			initOptions: map[string]interface{}{
+				"features": map[string]interface{}{
+					"codeActions": false,
+					"codeLens":    true,
+				},
+			},
+			checkCaps: func(t *testing.T, caps protocol.ServerCapabilities) {
+				assert.NotNil(t, caps.CodeLensProvider)
+				require.NotNil(t, caps.ExecuteCommandProvider)
+				assert.Equal(t, []string{"hledger.fixUnbalanced"}, caps.ExecuteCommandProvider.Commands)
 			},
 		},
 	}

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -14,12 +14,28 @@ type integrationMockClient struct {
 	mu            sync.Mutex
 	diagnostics   []protocol.PublishDiagnosticsParams
 	diagnosticsCh chan struct{}
+
+	applyMu   sync.Mutex
+	lastApply *protocol.ApplyWorkspaceEditParams
 }
 
 func newIntegrationMockClient() *integrationMockClient {
 	return &integrationMockClient{
 		diagnosticsCh: make(chan struct{}, 100),
 	}
+}
+
+func (m *integrationMockClient) ApplyEdit(_ context.Context, params *protocol.ApplyWorkspaceEditParams) (bool, error) {
+	m.applyMu.Lock()
+	m.lastApply = params
+	m.applyMu.Unlock()
+	return true, nil
+}
+
+func (m *integrationMockClient) lastApplyEdit() *protocol.ApplyWorkspaceEditParams {
+	m.applyMu.Lock()
+	defer m.applyMu.Unlock()
+	return m.lastApply
 }
 
 func (m *integrationMockClient) Progress(_ context.Context, _ *protocol.ProgressParams) error {
@@ -64,10 +80,6 @@ func (m *integrationMockClient) RegisterCapability(_ context.Context, _ *protoco
 
 func (m *integrationMockClient) UnregisterCapability(_ context.Context, _ *protocol.UnregistrationParams) error {
 	return nil
-}
-
-func (m *integrationMockClient) ApplyEdit(_ context.Context, _ *protocol.ApplyWorkspaceEditParams) (bool, error) {
-	return false, nil
 }
 
 func (m *integrationMockClient) Configuration(_ context.Context, _ *protocol.ConfigurationParams) ([]interface{}, error) {


### PR DESCRIPTION
Fixes #38 by making undeclared account and commodity diagnostics actionable and allowing users to apply the unbalanced transaction fix from the code lens.

## Changes

- Add quick fixes for `UNDECLARED_ACCOUNT` and `UNDECLARED_COMMODITY`.
- Insert directives after the last declaration of the same kind in the current or included file.
- Quote commodity names when required by the journal syntax.
- Add `hledger.fixUnbalanced` and apply its edit through `workspace/applyEdit`.
- Cover CRLF, CJK, include-tree, command serialization, and feature-capability cases.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `golangci-lint run ./...`

## Code pointers

- `internal/server/code_action.go`
- `internal/server/codelens.go`
- `internal/server/server.go`
- `internal/server/code_action_declarations_test.go`
