### PR TITLE
fix(server): search workspace include tree in symbol index (#37)

### DIFF
--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1155,3 +1155,114 @@ commodity "TEST.A"
 			"declared unquoted USD must match quoted usage")
 	})
 }
+
+func TestAnalyzeResolved_DeterministicOrder(t *testing.T) {
+	file1 := `account expenses:food
+account assets:cash
+commodity USD
+commodity EUR
+
+2024-01-10 Grocery Store
+    expenses:food  $50.00
+    assets:cash
+
+2024-01-11 Coffee Shop ;tag: coffee
+    expenses:food  $5.00
+    assets:cash
+`
+	file2 := `account expenses:rent
+account assets:bank
+commodity GBP
+
+2024-02-01 Landlord
+    expenses:rent  $1000.00
+    assets:bank
+
+2024-02-02 Grocery Store ;tag: groceries
+    expenses:food  $75.00
+    assets:bank
+`
+	file3 := `account expenses:utilities
+account liabilities:credit
+commodity JPY
+
+2024-03-01 Electric Company
+    expenses:utilities  $120.00
+    liabilities:credit
+
+2024-03-02 Coffee Shop
+    expenses:food  $6.00
+    liabilities:credit
+`
+	j1, errs1 := parser.Parse(file1)
+	require.Empty(t, errs1)
+	j2, errs2 := parser.Parse(file2)
+	require.Empty(t, errs2)
+	j3, errs3 := parser.Parse(file3)
+	require.Empty(t, errs3)
+
+	legacyResolved := &include.ResolvedJournal{
+		Primary: j1,
+		Files: map[string]*ast.Journal{
+			"/f2.journal": j2,
+			"/f3.journal": j3,
+		},
+		FileOrder: []string{"/f2.journal", "/f3.journal"},
+	}
+
+	occResolved := &include.ResolvedJournal{
+		Occurrences: []include.JournalOccurrence{
+			{ID: 1, Path: "/f1.journal", Journal: j1},
+			{ID: 2, Path: "/f2.journal", Journal: j2},
+			{ID: 3, Path: "/f3.journal", Journal: j3},
+		},
+		Primary:   j1,
+		Files:     map[string]*ast.Journal{"/f2.journal": j2, "/f3.journal": j3},
+		FileOrder: []string{"/f2.journal", "/f3.journal"},
+	}
+	// Build Items so AllTransactions uses the occurrence path.
+	for _, occ := range occResolved.Occurrences {
+		for i := range occ.Journal.Transactions {
+			occResolved.Items = append(occResolved.Items, include.ResolvedItem{
+				OccurrenceID: occ.ID,
+				Kind:         include.ResolvedItemTransaction,
+				Index:        i,
+			})
+		}
+	}
+
+	a := New()
+
+	for name, resolved := range map[string]*include.ResolvedJournal{
+		"legacy":     legacyResolved,
+		"occurrence": occResolved,
+	} {
+		t.Run(name, func(t *testing.T) {
+			first := a.AnalyzeResolved(resolved)
+			require.NotEmpty(t, first.Payees)
+			require.NotEmpty(t, first.Commodities)
+			require.NotEmpty(t, first.Tags)
+			require.NotEmpty(t, first.Dates)
+			require.NotEmpty(t, first.Accounts.All)
+
+			for i := 1; i < 20; i++ {
+				got := a.AnalyzeResolved(resolved)
+				assert.Equal(t, first.Payees, got.Payees, "iter %d: Payees", i)
+				assert.Equal(t, first.Descriptions, got.Descriptions, "iter %d: Descriptions", i)
+				assert.Equal(t, first.Commodities, got.Commodities, "iter %d: Commodities", i)
+				assert.Equal(t, first.Tags, got.Tags, "iter %d: Tags", i)
+				assert.Equal(t, first.Dates, got.Dates, "iter %d: Dates", i)
+				assert.Equal(t, first.Accounts.All, got.Accounts.All, "iter %d: Accounts.All", i)
+				assert.Equal(t, first.TagValues, got.TagValues, "iter %d: TagValues", i)
+				assert.Equal(t, first.PayeeTemplates, got.PayeeTemplates, "iter %d: PayeeTemplates", i)
+				assert.Equal(t, first.PayeeAccounts, got.PayeeAccounts, "iter %d: PayeeAccounts", i)
+
+				require.Len(t, got.Diagnostics, len(first.Diagnostics), "iter %d: Diagnostics len", i)
+				for d := range first.Diagnostics {
+					assert.Equal(t, first.Diagnostics[d].Message, got.Diagnostics[d].Message, "iter %d: Diagnostics[%d].Message", i, d)
+					assert.Equal(t, first.Diagnostics[d].Code, got.Diagnostics[d].Code, "iter %d: Diagnostics[%d].Code", i, d)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/workspace_symbol.go
+++ b/internal/server/workspace_symbol.go
@@ -13,18 +13,61 @@ import (
 func (s *Server) WorkspaceSymbol(ctx context.Context, params *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
 	query := strings.ToLower(params.Query)
 
+	type symbolKey struct {
+		name      string
+		kind      protocol.SymbolKind
+		uri       protocol.DocumentURI
+		startLine uint32
+		startChar uint32
+	}
+	seen := make(map[symbolKey]bool)
 	var symbols []protocol.SymbolInformation
 
-	s.documents.Range(func(key, value any) bool {
-		uri := key.(protocol.DocumentURI)
-		content := value.(string)
+	addSymbols := func(journal *ast.Journal, docURI protocol.DocumentURI) {
+		for _, sym := range extractSymbols(journal, docURI, query) {
+			key := symbolKey{
+				name:      sym.Name,
+				kind:      sym.Kind,
+				uri:       sym.Location.URI,
+				startLine: sym.Location.Range.Start.Line,
+				startChar: sym.Location.Range.Start.Character,
+			}
+			if !seen[key] {
+				seen[key] = true
+				symbols = append(symbols, sym)
+			}
+		}
+	}
 
+	coveredPaths := make(map[string]bool)
+
+	if s.workspace != nil {
+		for _, tree := range s.workspace.AllTrees() {
+			if tree.Resolved == nil {
+				continue
+			}
+			for i := range tree.Resolved.Occurrences {
+				occ := &tree.Resolved.Occurrences[i]
+				if occ.Journal == nil {
+					continue
+				}
+				coveredPaths[occ.Path] = true
+				addSymbols(occ.Journal, pathToURI(occ.Path))
+			}
+		}
+	}
+
+	s.documents.Range(func(key, value any) bool {
+		docURI := key.(protocol.DocumentURI)
+		if path := uriToPath(docURI); path != "" && coveredPaths[path] {
+			return true
+		}
+		content := value.(string)
 		journal, _ := parser.Parse(content)
 		if journal == nil {
 			return true
 		}
-
-		symbols = append(symbols, extractSymbols(journal, uri, query)...)
+		addSymbols(journal, docURI)
 		return true
 	})
 

--- a/internal/server/workspace_symbol_test.go
+++ b/internal/server/workspace_symbol_test.go
@@ -2,11 +2,16 @@ package server
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/workspace"
 )
 
 func TestWorkspaceSymbol_Accounts(t *testing.T) {
@@ -135,4 +140,108 @@ func TestWorkspaceSymbol_NoMatches(t *testing.T) {
 	result, err := srv.WorkspaceSymbol(context.Background(), params)
 	require.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+func setupWorkspaceServer(t *testing.T, files map[string]string) *Server {
+	t.Helper()
+	tmpDir := t.TempDir()
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0o644))
+	}
+	srv := NewServer()
+	srv.loader = include.NewLoader()
+	srv.workspace = workspace.NewWorkspace(tmpDir, srv.loader)
+	require.NoError(t, srv.workspace.Initialize())
+	return srv
+}
+
+func TestWorkspaceSymbol_NonOpenIncludeTreeFile(t *testing.T) {
+	srv := setupWorkspaceServer(t, map[string]string{
+		"main.journal":  "include child.journal\n\naccount assets:cash\n\n2024-01-01 Main Payee\n    assets:cash  $1\n    expenses:x\n",
+		"child.journal": "account expenses:food\ncommodity EUR\n\n2024-02-01 Child Payee\n    expenses:food  10 EUR\n    assets:cash\n",
+	})
+
+	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "child"})
+	require.NoError(t, err)
+
+	var names []string
+	for _, s := range result {
+		names = append(names, s.Name)
+	}
+	assert.Contains(t, names, "Child Payee", "payee from non-open included file")
+
+	result, err = srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "expenses:food"})
+	require.NoError(t, err)
+	require.NotEmpty(t, result, "account from non-open included file")
+	assert.Equal(t, protocol.SymbolKindClass, result[0].Kind)
+
+	result, err = srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "EUR"})
+	require.NoError(t, err)
+	require.NotEmpty(t, result, "commodity from non-open included file")
+	assert.Equal(t, protocol.SymbolKindEnum, result[0].Kind)
+}
+
+func TestWorkspaceSymbol_DeduplicatesRepeatedIncludes(t *testing.T) {
+	srv := setupWorkspaceServer(t, map[string]string{
+		"main.journal":   "include shared.journal\ninclude shared.journal\n\n2024-01-01 Root\n    assets:cash  $1\n    expenses:x\n",
+		"shared.journal": "account expenses:shared\n\n2024-03-01 Shared Payee\n    expenses:shared  $5\n    assets:cash\n",
+	})
+
+	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "Shared Payee"})
+	require.NoError(t, err)
+
+	count := 0
+	for _, s := range result {
+		if s.Name == "Shared Payee" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "repeated include must not duplicate symbols")
+}
+
+func TestWorkspaceSymbol_FallbackWithoutWorkspace(t *testing.T) {
+	srv := NewServer()
+	content := "account expenses:food\n\n2024-01-15 test\n    expenses:food  $50\n    assets:cash"
+	uri := protocol.DocumentURI("file:///test.journal")
+	srv.documents.Store(uri, content)
+
+	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "expenses"})
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+	assert.Equal(t, "expenses:food", result[0].Name)
+}
+
+func TestWorkspaceSymbol_OpenFileOutsideTree(t *testing.T) {
+	srv := setupWorkspaceServer(t, map[string]string{
+		"main.journal": "account assets:cash\n",
+	})
+
+	outsideURI := protocol.DocumentURI("file:///tmp/outside.journal")
+	srv.documents.Store(outsideURI, "account expenses:outside\n\n2024-01-01 Outside Payee\n    expenses:outside  $1\n    assets:x\n")
+
+	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "outside"})
+	require.NoError(t, err)
+
+	var names []string
+	for _, s := range result {
+		names = append(names, s.Name)
+	}
+	assert.Contains(t, names, "expenses:outside", "account from open file outside workspace tree")
+	assert.Contains(t, names, "Outside Payee", "payee from open file outside workspace tree")
+}
+
+func TestWorkspaceSymbol_NonOpenFile_CRLF_Unicode(t *testing.T) {
+	srv := setupWorkspaceServer(t, map[string]string{
+		"main.journal":  "include child.journal\n\naccount assets:cash\n",
+		"child.journal": "account расходы:еда\r\n\r\n2024-01-01 Магазин\r\n    расходы:еда  100 RUB\r\n    assets:cash\r\n",
+	})
+
+	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "расходы"})
+	require.NoError(t, err)
+	require.NotEmpty(t, result, "CJK/Cyrillic account from non-open CRLF file")
+	assert.Equal(t, "расходы:еда", result[0].Name)
+
+	result, err = srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "Магазин"})
+	require.NoError(t, err)
+	require.NotEmpty(t, result, "Cyrillic payee from non-open CRLF file")
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -330,6 +330,13 @@ func (w *Workspace) sortedTrees() []*IncludeTree {
 	return result
 }
 
+// AllTrees returns all include trees in deterministic order (sorted by root path).
+func (w *Workspace) AllTrees() []*IncludeTree {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.sortedTrees()
+}
+
 func (w *Workspace) IndexSnapshot() IndexSnapshot {
 	w.mu.RLock()
 	defer w.mu.RUnlock()

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1269,3 +1269,28 @@ func TestWorkspace_GetResolvedForFile_RepeatedInclude(t *testing.T) {
 	allTx := resolved.AllTransactions()
 	assert.Len(t, allTx, 3, "child tx counted twice + root tx once")
 }
+
+func TestWorkspace_AllTrees(t *testing.T) {
+	t.Setenv("LEDGER_FILE", "")
+	t.Setenv("HLEDGER_JOURNAL", "")
+
+	tmpDir := t.TempDir()
+
+	// Two independent root journals → two trees.
+	bPath := filepath.Join(tmpDir, "b.journal")
+	require.NoError(t, os.WriteFile(bPath, []byte("account assets:b\n"), 0644))
+
+	aPath := filepath.Join(tmpDir, "a.journal")
+	require.NoError(t, os.WriteFile(aPath, []byte("account assets:a\n"), 0644))
+
+	ws := NewWorkspace(tmpDir, include.NewLoader())
+	require.NoError(t, ws.Initialize())
+
+	trees := ws.AllTrees()
+	require.Len(t, trees, 2)
+	assert.Equal(t, aPath, trees[0].RootPath, "sorted lexicographically")
+	assert.Equal(t, bPath, trees[1].RootPath)
+	for _, tree := range trees {
+		assert.NotNil(t, tree.Resolved)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #37.

**Bug 1 (nondeterminism):** Already fixed by PR #55 — all `collect*FromResolved` use deterministic `SourceJournals()`. This PR adds a regression test (`TestAnalyzeResolved_DeterministicOrder`, 20 iterations, both legacy and occurrence paths, all slice/map fields).

**Bug 2 (workspace symbol scope):** `WorkspaceSymbol` only searched open editor tabs (`s.documents`). Rewritten to iterate workspace include trees via new `AllTrees()`, extracting symbols from already-parsed occurrence ASTs. Dedup by `(name, kind, URI, range)`. Open documents outside any tree fall back to `s.documents`.

## Changes

| File | Change |
|---|---|
| `internal/workspace/workspace.go` | +`AllTrees()` public method |
| `internal/server/workspace_symbol.go` | Rewrite to use workspace trees |
| `internal/analyzer/analyzer_test.go` | +determinism regression test |
| `internal/workspace/workspace_test.go` | +`AllTrees` test |
| `internal/server/workspace_symbol_test.go` | +5 tests (non-open file, dedup, fallback, outside-tree, CRLF+Unicode) |

## Verification

- `go test -race ./...` — 14 packages PASS
- `golangci-lint run` — 0 issues
- Acceptance criteria from #37:
  - [x] Repeated `AnalyzeResolved` on the same input yields identical ordering
  - [x] Workspace symbol finds symbols defined in non-open include-tree files