### PR TITLE
fix: code health and minor correctness (S4 checklist, #39)

### DIFF
--- a/cmd/hledger-lsp/main.go
+++ b/cmd/hledger-lsp/main.go
@@ -277,7 +277,11 @@ func (d *serverDispatcher) SemanticTokensFull(ctx context.Context, params *proto
 }
 
 func (d *serverDispatcher) SemanticTokensFullDelta(ctx context.Context, params *protocol.SemanticTokensDeltaParams) (any, error) {
-	return d.srv.SemanticTokensFullDelta(ctx, params)
+	// Delta is not advertised (Delta: false); clients should not call this.
+	// Fall back to a full response for safety.
+	return d.srv.SemanticTokensFull(ctx, &protocol.SemanticTokensParams{
+		TextDocument: params.TextDocument,
+	})
 }
 
 func (d *serverDispatcher) SemanticTokensRange(ctx context.Context, params *protocol.SemanticTokensRangeParams) (*protocol.SemanticTokens, error) {

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/shopspring/decimal"
@@ -50,6 +51,7 @@ func (a *Analyzer) analyzeInternal(journal *ast.Journal, external ExternalDeclar
 	for k := range external.Accounts {
 		declaredAccounts[k] = true
 	}
+	sortedDeclared := sortedKeys(declaredAccounts)
 
 	declaredCommodities := collectDeclaredCommodities(journal)
 	for k := range external.Commodities {
@@ -65,8 +67,8 @@ func (a *Analyzer) analyzeInternal(journal *ast.Journal, external ExternalDeclar
 			result.Diagnostics = append(result.Diagnostics, diag)
 		}
 
-		if len(declaredAccounts) > 0 {
-			undeclaredDiags := checkUndeclaredAccounts(tx, declaredAccounts)
+		if len(sortedDeclared) > 0 {
+			undeclaredDiags := checkUndeclaredAccounts(tx, sortedDeclared)
 			result.Diagnostics = append(result.Diagnostics, undeclaredDiags...)
 		}
 
@@ -123,6 +125,7 @@ func (a *Analyzer) AnalyzeResolved(resolved *include.ResolvedJournal) *AnalysisR
 	result.PayeeAccountPairUsage = collectPayeeAccountPairUsageFromResolved(resolved)
 
 	declaredAccounts := collectDeclaredAccountsFromResolved(resolved)
+	sortedDeclared := sortedKeys(declaredAccounts)
 	declaredCommodities := collectDeclaredCommoditiesFromResolved(resolved)
 
 	// Generate diagnostics for all occurrences, then dedup identical ones
@@ -142,8 +145,8 @@ func (a *Analyzer) AnalyzeResolved(resolved *include.ResolvedJournal) *AnalysisR
 		if !balanceResult.Balanced {
 			txDiags = append(txDiags, a.createBalanceDiagnostic(&tx, balanceResult))
 		}
-		if len(declaredAccounts) > 0 {
-			txDiags = append(txDiags, checkUndeclaredAccounts(&tx, declaredAccounts)...)
+		if len(sortedDeclared) > 0 {
+			txDiags = append(txDiags, checkUndeclaredAccounts(&tx, sortedDeclared)...)
 		}
 		if len(declaredCommodities) > 0 {
 			txDiags = append(txDiags, checkUndeclaredCommodities(&tx, declaredCommodities)...)
@@ -433,7 +436,16 @@ var predefinedAccountTypes = map[string]bool{
 	"income":      true,
 }
 
-func isAccountDeclared(accountName string, declared map[string]bool) bool {
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func isAccountDeclared(accountName string, sortedDeclared []string) bool {
 	lowerName := strings.ToLower(accountName)
 	colonIdx := strings.Index(lowerName, ":")
 	var prefix string
@@ -446,21 +458,32 @@ func isAccountDeclared(accountName string, declared map[string]bool) bool {
 		return true
 	}
 
-	if declared[accountName] {
+	// Exact match via binary search
+	i := sort.SearchStrings(sortedDeclared, accountName)
+	if i < len(sortedDeclared) && sortedDeclared[i] == accountName {
 		return true
 	}
-	for declaredAccount := range declared {
-		if strings.HasPrefix(accountName, declaredAccount+":") {
+
+	// Prefix match: check each ancestor (e.g. "a:b:c" → "a:b", "a")
+	name := accountName
+	for {
+		idx := strings.LastIndex(name, ":")
+		if idx == -1 {
+			break
+		}
+		name = name[:idx]
+		i := sort.SearchStrings(sortedDeclared, name)
+		if i < len(sortedDeclared) && sortedDeclared[i] == name {
 			return true
 		}
 	}
 	return false
 }
 
-func checkUndeclaredAccounts(tx *ast.Transaction, declared map[string]bool) []Diagnostic {
+func checkUndeclaredAccounts(tx *ast.Transaction, sortedDeclared []string) []Diagnostic {
 	var diags []Diagnostic
 	for _, posting := range tx.Postings {
-		if !isAccountDeclared(posting.Account.GetResolvedName(), declared) {
+		if !isAccountDeclared(posting.Account.GetResolvedName(), sortedDeclared) {
 			diags = append(diags, Diagnostic{
 				Range:    posting.Account.Range,
 				Severity: SeverityWarning,

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -568,12 +568,7 @@ func (l *Lexer) scanDirectiveOrAccount() Token {
 		l.column = tempCol
 	}
 
-	// If not a directive, continue scanning with digits for potential account
-	for l.pos < len(l.input) && l.isDigit(l.peek()) {
-		l.advance()
-	}
-
-	// Reset and check if it looks like account
+	// Reset to start so looksLikeAccount/scanAccount see the full token
 	l.pos = start
 	l.column = startPos.Column
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -633,6 +633,7 @@ func (p *Parser) parseAmount() *ast.Amount {
 
 	if p.current.Type != TokenNumber {
 		p.error("expected number")
+		p.skipToNextLine()
 		return nil
 	}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -4029,3 +4029,13 @@ func TestParser_BalanceAssertionUnclosedLotPrice(t *testing.T) {
 	require.NotNil(t, ba.LotPrice.Cost)
 	assert.True(t, ba.LotPrice.Cost.Quantity.Equal(decimal.NewFromInt(150)))
 }
+
+func TestParser_ParseAmount_NoDuplicateDiagnostic(t *testing.T) {
+	input := `2024-01-15 test
+    expenses:food  $
+    assets:cash`
+
+	_, errs := Parse(input)
+	require.Len(t, errs, 1, "expected exactly one error for missing number after commodity, got: %v", errs)
+	assert.Contains(t, errs[0].Message, "expected number")
+}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -312,7 +312,7 @@ func TestIntegration_DocumentSymbols(t *testing.T) {
 	}
 	symbols, err := ts.DocumentSymbol(context.Background(), params)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(symbols), 3)
+	require.GreaterOrEqual(t, len(symbols), 2, "month group + account directive")
 }
 
 func TestIntegration_SemanticTokens(t *testing.T) {

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"go.lsp.dev/protocol"
 
@@ -24,6 +26,10 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 }
 
 func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
+	if err := validateAccountName(params.NewName); err != nil {
+		return nil, err
+	}
+
 	doc, ok := s.getJournalDoc(params.TextDocument.URI)
 	if !ok {
 		return nil, nil
@@ -54,4 +60,20 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 	return &protocol.WorkspaceEdit{
 		Changes: changes,
 	}, nil
+}
+
+func validateAccountName(name string) error {
+	if name == "" {
+		return fmt.Errorf("account name must not be empty")
+	}
+	if name != strings.TrimSpace(name) {
+		return fmt.Errorf("account name must not have leading or trailing whitespace")
+	}
+	for _, r := range name {
+		switch r {
+		case ';', '\n', '\r':
+			return fmt.Errorf("account name contains illegal character %q", r)
+		}
+	}
+	return nil
 }

--- a/internal/server/rename_test.go
+++ b/internal/server/rename_test.go
@@ -202,3 +202,37 @@ func TestRename_IncludesDeclaration(t *testing.T) {
 	edits := changes[uri]
 	assert.Len(t, edits, 2)
 }
+
+func TestRename_InvalidNewName(t *testing.T) {
+	srv := NewServer()
+	content := `2024-01-15 test
+    expenses:food  $50
+    assets:cash`
+	uri := protocol.DocumentURI("file:///test.journal")
+	srv.documents.Store(uri, content)
+
+	tests := []struct {
+		name    string
+		newName string
+	}{
+		{"empty", ""},
+		{"semicolon", "expenses;food"},
+		{"newline", "expenses\nfood"},
+		{"leading space", " expenses:food"},
+		{"trailing space", "expenses:food "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &protocol.RenameParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+					Position:     protocol.Position{Line: 1, Character: 10},
+				},
+				NewName: tt.newName,
+			}
+			_, err := srv.Rename(context.Background(), params)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/internal/server/semantic.go
+++ b/internal/server/semantic.go
@@ -86,7 +86,7 @@ func GetSemanticTokensCapabilities() *SemanticTokensServerCapabilities {
 	return &SemanticTokensServerCapabilities{
 		Legend: GetSemanticTokensLegend(),
 		Range:  true,
-		Full:   &SemanticTokensFullOptions{Delta: true},
+		Full:   &SemanticTokensFullOptions{Delta: false},
 	}
 }
 
@@ -129,15 +129,10 @@ type cachedSemanticTokens struct {
 	data     []uint32
 }
 
-var tokenCache = &semanticTokensCache{
-	cache: make(map[protocol.DocumentURI]*cachedSemanticTokens),
-}
-
-func (c *semanticTokensCache) get(uri protocol.DocumentURI) (*cachedSemanticTokens, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	cached, ok := c.cache[uri]
-	return cached, ok
+func newSemanticTokensCache() *semanticTokensCache {
+	return &semanticTokensCache{
+		cache: make(map[protocol.DocumentURI]*cachedSemanticTokens),
+	}
 }
 
 func (c *semanticTokensCache) set(uri protocol.DocumentURI, tokens []semanticToken, data []uint32) string {
@@ -171,7 +166,7 @@ func (s *Server) SemanticTokensFull(ctx context.Context, params *protocol.Semant
 
 	tokens := tokenizeDoc(params.TextDocument.URI, doc)
 	data := encodeTokens(tokens)
-	resultID := tokenCache.set(params.TextDocument.URI, tokens, data)
+	resultID := s.tokenCache.set(params.TextDocument.URI, tokens, data)
 
 	return &protocol.SemanticTokens{
 		ResultID: resultID,
@@ -195,37 +190,6 @@ func (s *Server) SemanticTokensRange(ctx context.Context, params *protocol.Seman
 
 	return &protocol.SemanticTokens{
 		Data: data,
-	}, nil
-}
-
-func (s *Server) SemanticTokensFullDelta(ctx context.Context, params *protocol.SemanticTokensDeltaParams) (any, error) {
-	doc, ok := s.GetDocument(params.TextDocument.URI)
-	if !ok {
-		return &protocol.SemanticTokens{Data: []uint32{}}, nil
-	}
-
-	if doc == "" {
-		return &protocol.SemanticTokens{Data: []uint32{}}, nil
-	}
-
-	tokens := tokenizeDoc(params.TextDocument.URI, doc)
-	newData := encodeTokens(tokens)
-
-	cached, ok := tokenCache.get(params.TextDocument.URI)
-	if !ok || cached.resultID != params.PreviousResultID {
-		resultID := tokenCache.set(params.TextDocument.URI, tokens, newData)
-		return &protocol.SemanticTokens{
-			ResultID: resultID,
-			Data:     newData,
-		}, nil
-	}
-
-	edits := computeSemanticTokensEdits(cached.data, newData)
-	resultID := tokenCache.set(params.TextDocument.URI, tokens, newData)
-
-	return &protocol.SemanticTokensDelta{
-		ResultID: resultID,
-		Edits:    edits,
 	}, nil
 }
 
@@ -280,29 +244,6 @@ func filterTokensByRange(tokens []semanticToken, r protocol.Range) []semanticTok
 		}
 	}
 	return filtered
-}
-
-func computeSemanticTokensEdits(oldData, newData []uint32) []protocol.SemanticTokensEdit {
-	if len(oldData) == len(newData) {
-		same := true
-		for i := range oldData {
-			if oldData[i] != newData[i] {
-				same = false
-				break
-			}
-		}
-		if same {
-			return []protocol.SemanticTokensEdit{}
-		}
-	}
-
-	return []protocol.SemanticTokensEdit{
-		{
-			Start:       0,
-			DeleteCount: uint32(len(oldData)),
-			Data:        newData,
-		},
-	}
 }
 
 type semanticToken struct {

--- a/internal/server/semantic_test.go
+++ b/internal/server/semantic_test.go
@@ -292,42 +292,10 @@ func TestSemanticTokens_Range(t *testing.T) {
 		"range result should have fewer tokens than full result")
 }
 
-func TestSemanticTokens_Delta(t *testing.T) {
-	srv := NewServer()
-	uri := protocol.DocumentURI("file:///test.journal")
-
-	content1 := `2024-01-01 test
-    expenses:food  $10`
-	srv.documents.Store(uri, content1)
-
-	fullParams := &protocol.SemanticTokensParams{
-		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-	}
-	fullResult, err := srv.SemanticTokensFull(context.Background(), fullParams)
-	require.NoError(t, err)
-	require.NotEmpty(t, fullResult.ResultID)
-
-	content2 := `2024-01-01 test
-    expenses:food  $20`
-	srv.documents.Store(uri, content2)
-
-	deltaParams := &protocol.SemanticTokensDeltaParams{
-		TextDocument:     protocol.TextDocumentIdentifier{URI: uri},
-		PreviousResultID: fullResult.ResultID,
-	}
-
-	deltaResult, err := srv.SemanticTokensFullDelta(context.Background(), deltaParams)
-	require.NoError(t, err)
-	require.NotNil(t, deltaResult)
-
-	switch result := deltaResult.(type) {
-	case *protocol.SemanticTokens:
-		assert.NotEmpty(t, result.Data)
-	case *protocol.SemanticTokensDelta:
-		assert.NotNil(t, result.Edits)
-	default:
-		t.Fatalf("unexpected result type: %T", deltaResult)
-	}
+func TestSemanticTokens_DeltaNotAdvertised(t *testing.T) {
+	caps := GetSemanticTokensCapabilities()
+	require.NotNil(t, caps.Full)
+	assert.False(t, caps.Full.Delta, "delta should not be advertised")
 }
 
 func TestSemanticTokens_CommentLength(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,7 @@ type Server struct {
 	supportsConfiguration bool
 	payeeTemplatesCache   sync.Map // map[protocol.DocumentURI]map[string][]analyzer.PostingTemplate
 	alignmentCache        sync.Map // map[protocol.DocumentURI]int
+	tokenCache            *semanticTokensCache
 
 	diagDebounce time.Duration
 	diagMu       sync.Mutex
@@ -64,6 +65,7 @@ func NewServer() *Server {
 		rulesLoader:  rules.NewLoader(),
 		diagDebounce: 100 * time.Millisecond,
 		diagEntries:  make(map[protocol.DocumentURI]*diagEntry),
+		tokenCache:   newSemanticTokensCache(),
 	}
 	// Honour unsaved editor content for .rules files that are pulled in via
 	// transitive `include` from a currently-open rules file. The loader first
@@ -123,6 +125,10 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 
 	settings := s.getSettings()
 
+	// Feature flags gate capability registration at Initialize only.
+	// LSP capabilities are static after the Initialize handshake; toggling
+	// a feature via DidChangeConfiguration requires a server restart to
+	// take effect. This is a protocol limitation, not a bug.
 	caps := protocol.ServerCapabilities{
 		TextDocumentSync: protocol.TextDocumentSyncOptions{
 			OpenClose: true,
@@ -316,7 +322,7 @@ func (s *Server) DidClose(ctx context.Context, params *protocol.DidCloseTextDocu
 	s.cancelDiagnostics(params.TextDocument.URI)
 	s.documents.Delete(params.TextDocument.URI)
 	s.alignmentCache.Delete(params.TextDocument.URI)
-	tokenCache.delete(params.TextDocument.URI)
+	s.tokenCache.delete(params.TextDocument.URI)
 	return nil
 }
 

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -179,6 +179,8 @@ func (s *Server) refreshConfiguration(ctx context.Context) {
 	s.setSettings(settings)
 }
 
+// DidChangeConfiguration refreshes cached settings but cannot change
+// registered capabilities — feature flag changes require a server restart.
 func (s *Server) DidChangeConfiguration(_ context.Context, _ *protocol.DidChangeConfigurationParams) error {
 	go s.refreshConfiguration(context.Background())
 	return nil

--- a/internal/server/symbol.go
+++ b/internal/server/symbol.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"go.lsp.dev/protocol"
 
@@ -32,9 +33,7 @@ func (s *Server) DocumentSymbol(
 
 	var symbols []any
 
-	for _, tx := range journal.Transactions {
-		symbols = append(symbols, transactionToSymbol(tx))
-	}
+	symbols = append(symbols, groupTransactionsByMonth(journal.Transactions)...)
 
 	for _, dir := range journal.Directives {
 		symbols = append(symbols, directiveToSymbol(dir))
@@ -45,6 +44,53 @@ func (s *Server) DocumentSymbol(
 	}
 
 	return symbols, nil
+}
+
+func groupTransactionsByMonth(transactions []ast.Transaction) []any {
+	if len(transactions) == 0 {
+		return nil
+	}
+
+	type monthGroup struct {
+		label    string
+		first    ast.Transaction
+		last     ast.Transaction
+		children []protocol.DocumentSymbol
+	}
+
+	groups := make(map[string]*monthGroup)
+	var order []string
+
+	for _, tx := range transactions {
+		key := fmt.Sprintf("%04d-%02d", tx.Date.Year, tx.Date.Month)
+		g, ok := groups[key]
+		if !ok {
+			g = &monthGroup{label: key, first: tx, last: tx}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.last = tx
+		g.children = append(g.children, transactionToSymbol(tx))
+	}
+
+	sort.Strings(order)
+
+	result := make([]any, 0, len(order))
+	for _, key := range order {
+		g := groups[key]
+		rng := *astRangeToProtocol(ast.Range{
+			Start: g.first.Range.Start,
+			End:   g.last.Range.End,
+		})
+		result = append(result, protocol.DocumentSymbol{
+			Name:           g.label,
+			Kind:           protocol.SymbolKindNamespace,
+			Range:          rng,
+			SelectionRange: rng,
+			Children:       g.children,
+		})
+	}
+	return result
 }
 
 func includeToSymbol(inc ast.Include) protocol.DocumentSymbol {

--- a/internal/server/symbol_test.go
+++ b/internal/server/symbol_test.go
@@ -58,17 +58,21 @@ func TestDocumentSymbol_Transactions(t *testing.T) {
 
 	result, err := srv.DocumentSymbol(context.Background(), params)
 	require.NoError(t, err)
-	require.Len(t, result, 2)
+	require.Len(t, result, 1, "transactions grouped by month")
 
 	symbols := toDocumentSymbols(t, result)
 
-	assert.Equal(t, "2024-01-15 grocery store", symbols[0].Name)
-	assert.Equal(t, protocol.SymbolKindFunction, symbols[0].Kind)
-	assert.Equal(t, uint32(0), symbols[0].Range.Start.Line)
+	assert.Equal(t, "2024-01", symbols[0].Name)
+	assert.Equal(t, protocol.SymbolKindNamespace, symbols[0].Kind)
+	require.Len(t, symbols[0].Children, 2)
 
-	assert.Equal(t, "2024-01-16 restaurant", symbols[1].Name)
-	assert.Equal(t, protocol.SymbolKindFunction, symbols[1].Kind)
-	assert.Equal(t, uint32(4), symbols[1].Range.Start.Line)
+	assert.Equal(t, "2024-01-15 grocery store", symbols[0].Children[0].Name)
+	assert.Equal(t, protocol.SymbolKindFunction, symbols[0].Children[0].Kind)
+	assert.Equal(t, uint32(0), symbols[0].Children[0].Range.Start.Line)
+
+	assert.Equal(t, "2024-01-16 restaurant", symbols[0].Children[1].Name)
+	assert.Equal(t, protocol.SymbolKindFunction, symbols[0].Children[1].Kind)
+	assert.Equal(t, uint32(4), symbols[0].Children[1].Range.Start.Line)
 }
 
 func TestDocumentSymbol_AccountDirective(t *testing.T) {
@@ -176,7 +180,7 @@ include ./other.journal`
 
 	result, err := srv.DocumentSymbol(context.Background(), params)
 	require.NoError(t, err)
-	require.Len(t, result, 4)
+	require.Len(t, result, 4, "month group + account + commodity + include")
 
 	symbols := toDocumentSymbols(t, result)
 
@@ -185,10 +189,18 @@ include ./other.journal`
 		kindCounts[sym.Kind]++
 	}
 
+	assert.Equal(t, 1, kindCounts[protocol.SymbolKindNamespace], "month group")
 	assert.Equal(t, 1, kindCounts[protocol.SymbolKindClass])
 	assert.Equal(t, 1, kindCounts[protocol.SymbolKindEnum])
-	assert.Equal(t, 1, kindCounts[protocol.SymbolKindFunction])
 	assert.Equal(t, 1, kindCounts[protocol.SymbolKindModule])
+
+	// Transaction is nested inside the month group
+	for _, sym := range symbols {
+		if sym.Kind == protocol.SymbolKindNamespace {
+			require.Len(t, sym.Children, 1)
+			assert.Equal(t, protocol.SymbolKindFunction, sym.Children[0].Kind)
+		}
+	}
 }
 
 func toDocumentSymbols(t *testing.T, result []any) []protocol.DocumentSymbol {

--- a/internal/workspace/index.go
+++ b/internal/workspace/index.go
@@ -349,7 +349,7 @@ func copyNestedIntMap(source map[string]map[string]int) map[string]map[string]in
 }
 
 func BuildFileIndexFromContent(path, content string) (*FileIndex, *ast.Journal, []string) {
-	journal, parseErrs := parser.Parse(content)
+	journal, parseErrs := parser.Parse(normalizeLineEndings(content))
 	var errors []string
 	for _, err := range parseErrs {
 		errors = append(errors, err.Message)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -462,7 +463,7 @@ func removeString(values []string, target string) []string {
 	if len(values) == 0 {
 		return values
 	}
-	result := values[:0]
+	result := make([]string, 0, len(values))
 	for _, value := range values {
 		if value != target {
 			result = append(result, value)
@@ -521,7 +522,7 @@ func (w *Workspace) GetCommodityFormatsForFile(path string) map[string]formatter
 	}
 	if tree.cachedFormats != nil {
 		defer w.mu.RUnlock()
-		return tree.cachedFormats
+		return maps.Clone(tree.cachedFormats)
 	}
 	w.mu.RUnlock()
 
@@ -533,14 +534,14 @@ func (w *Workspace) GetCommodityFormatsForFile(path string) map[string]formatter
 		return nil
 	}
 	if tree.cachedFormats != nil {
-		return tree.cachedFormats
+		return maps.Clone(tree.cachedFormats)
 	}
 	if tree.Resolved == nil {
 		return nil
 	}
 
 	tree.cachedFormats = formatter.ExtractCommodityFormats(tree.Resolved.FormatDirectives())
-	return tree.cachedFormats
+	return maps.Clone(tree.cachedFormats)
 }
 
 // GetCommodityFormats returns commodity formats for the first tree (backward compatibility).

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1294,3 +1294,25 @@ func TestWorkspace_AllTrees(t *testing.T) {
 		assert.NotNil(t, tree.Resolved)
 	}
 }
+
+func TestBuildFileIndexFromContent_NormalizesCRLF(t *testing.T) {
+	lf := "2024-01-15 test\n    expenses:food  $50\n    assets:cash\n"
+	crlf := "2024-01-15 test\r\n    expenses:food  $50\r\n    assets:cash\r\n"
+
+	idxLF, journalLF, errsLF := BuildFileIndexFromContent("test.journal", lf)
+	idxCRLF, journalCRLF, errsCRLF := BuildFileIndexFromContent("test.journal", crlf)
+
+	assert.Equal(t, errsLF, errsCRLF)
+	require.NotNil(t, journalLF)
+	require.NotNil(t, journalCRLF)
+	assert.Len(t, journalCRLF.Transactions, len(journalLF.Transactions))
+	assert.Equal(t, idxLF.Includes, idxCRLF.Includes)
+}
+
+func TestRemoveString_DoesNotMutateOriginal(t *testing.T) {
+	original := []string{"a", "b", "c"}
+	result := removeString(original, "b")
+
+	assert.Equal(t, []string{"a", "c"}, result)
+	assert.Equal(t, []string{"a", "b", "c"}, original, "original slice must not be mutated")
+}


### PR DESCRIPTION
Closes #39

## Summary

All 9 items from the S4 checklist:

- **Dead work in lexer** — removed scan-and-rollback of digits in `scanDirectiveOrAccount`
- **CRLF at index boundary** — `BuildFileIndexFromContent` normalizes line endings on entry
- **`isAccountDeclared` O(P×D)** — replaced linear scan with sorted slice + binary search
- **`parseAmount` duplicate diagnostic** — added `skipToNextLine()` recovery
- **Rename without validation** — `validateAccountName` rejects `;`, `\n`, `\r`, leading/trailing whitespace
- **Flat DocumentSymbol** — transactions grouped by `YYYY-MM` with `SymbolKindNamespace`
- **Feature flags** — documented restart requirement (LSP capabilities are static after Initialize)
- **Semantic tokens fake delta** — `Delta: false`, removed `SemanticTokensFullDelta`/`computeSemanticTokensEdits`, per-server `tokenCache`
- **Workspace graph** — `removeString` allocates new slice (no shared backing array mutation), `GetCommodityFormatsForFile` returns `maps.Clone`

Note: `refreshTreeLocked` referenced in the issue does not exist; the BFS O(N×E) concern was not confirmed.

## Verification

- `go test -race ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues
- New tests for each behavior change