### PR TITLE
feat(server): payee-aware account suggestions (#41)

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -45,6 +45,7 @@ func (a *Analyzer) analyzeInternal(journal *ast.Journal, external ExternalDeclar
 		TagCounts:             CollectTagCounts(journal),
 		PayeeAccounts:         CollectPayeeAccounts(journal),
 		PayeeAccountPairUsage: CollectPayeeAccountPairUsage(journal),
+		PayeeAccountLastUsed:  CollectPayeeAccountLastUsed(journal),
 	}
 
 	declaredAccounts := collectDeclaredAccounts(journal)
@@ -102,6 +103,7 @@ func (a *Analyzer) AnalyzeResolved(resolved *include.ResolvedJournal) *AnalysisR
 		TagCounts:             make(map[string]int),
 		PayeeAccounts:         make(map[string][]string),
 		PayeeAccountPairUsage: make(map[string]int),
+		PayeeAccountLastUsed:  make(map[string]string),
 	}
 
 	if resolved == nil || resolved.Primary == nil {
@@ -123,6 +125,7 @@ func (a *Analyzer) AnalyzeResolved(resolved *include.ResolvedJournal) *AnalysisR
 	result.TagCounts = collectTagCountsFromResolved(resolved)
 	result.PayeeAccounts = collectPayeeAccountsFromResolved(resolved)
 	result.PayeeAccountPairUsage = collectPayeeAccountPairUsageFromResolved(resolved)
+	result.PayeeAccountLastUsed = collectPayeeAccountLastUsedFromResolved(resolved)
 
 	declaredAccounts := collectDeclaredAccountsFromResolved(resolved)
 	sortedDeclared := sortedKeys(declaredAccounts)

--- a/internal/analyzer/payee_accounts.go
+++ b/internal/analyzer/payee_accounts.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/juev/hledger-lsp/internal/ast"
@@ -120,4 +121,58 @@ func collectPayeeAccountPairUsageFromResolved(resolved *include.ResolvedJournal)
 	}
 
 	return counts
+}
+
+func formatDateKey(d ast.Date) string {
+	return fmt.Sprintf("%04d-%02d-%02d", d.Year, d.Month, d.Day)
+}
+
+func CollectPayeeAccountLastUsed(journal *ast.Journal) map[string]string {
+	lastUsed := make(map[string]string)
+
+	for _, tx := range journal.Transactions {
+		payee := tx.Payee
+		if payee == "" {
+			payee = tx.Description
+		}
+		if payee == "" {
+			continue
+		}
+
+		dateKey := formatDateKey(tx.Date)
+
+		for _, posting := range tx.Postings {
+			account := posting.Account.GetResolvedName()
+			if account == "" {
+				continue
+			}
+			key := payee + "::" + account
+			if existing, ok := lastUsed[key]; !ok || dateKey > existing {
+				lastUsed[key] = dateKey
+			}
+		}
+	}
+
+	return lastUsed
+}
+
+func collectPayeeAccountLastUsedFromResolved(resolved *include.ResolvedJournal) map[string]string {
+	lastUsed := make(map[string]string)
+
+	merge := func(journal *ast.Journal) {
+		if journal == nil {
+			return
+		}
+		for k, v := range CollectPayeeAccountLastUsed(journal) {
+			if existing, ok := lastUsed[k]; !ok || v > existing {
+				lastUsed[k] = v
+			}
+		}
+	}
+
+	for _, journal := range resolved.SourceJournals() {
+		merge(journal)
+	}
+
+	return lastUsed
 }

--- a/internal/analyzer/payee_accounts_test.go
+++ b/internal/analyzer/payee_accounts_test.go
@@ -222,3 +222,61 @@ end apply account`
 	assert.Equal(t, 1, result["Grocery Store::personal:expenses:food"])
 	assert.Equal(t, 1, result["Grocery Store::personal:assets:cash"])
 }
+
+func TestCollectPayeeAccountLastUsed_Empty(t *testing.T) {
+	journal, _ := parser.Parse(``)
+
+	result := CollectPayeeAccountLastUsed(journal)
+
+	assert.Empty(t, result)
+}
+
+func TestCollectPayeeAccountLastUsed_SingleTransaction(t *testing.T) {
+	input := `2024-01-15 Grocery Store
+    expenses:food  $50
+    assets:cash`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	result := CollectPayeeAccountLastUsed(journal)
+
+	assert.Equal(t, "2024-01-15", result["Grocery Store::expenses:food"])
+	assert.Equal(t, "2024-01-15", result["Grocery Store::assets:cash"])
+}
+
+func TestCollectPayeeAccountLastUsed_KeepsLatestDate(t *testing.T) {
+	input := `2024-01-15 Grocery Store
+    expenses:food  $50
+    assets:cash
+
+2024-03-20 Grocery Store
+    expenses:food  $30
+    assets:bank
+
+2024-02-10 Grocery Store
+    expenses:food  $20
+    assets:cash`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	result := CollectPayeeAccountLastUsed(journal)
+
+	assert.Equal(t, "2024-03-20", result["Grocery Store::expenses:food"])
+	assert.Equal(t, "2024-02-10", result["Grocery Store::assets:cash"])
+	assert.Equal(t, "2024-03-20", result["Grocery Store::assets:bank"])
+}
+
+func TestCollectPayeeAccountLastUsed_UsesDescriptionWhenNoPayee(t *testing.T) {
+	input := `2024-06-01 coffee shop
+    expenses:food  $5
+    assets:cash`
+
+	journal, errs := parser.Parse(input)
+	require.Empty(t, errs)
+
+	result := CollectPayeeAccountLastUsed(journal)
+
+	assert.Equal(t, "2024-06-01", result["coffee shop::expenses:food"])
+}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -41,6 +41,7 @@ type AnalysisResult struct {
 
 	PayeeAccounts         map[string][]string
 	PayeeAccountPairUsage map[string]int
+	PayeeAccountLastUsed  map[string]string
 }
 
 type PostingTemplate struct {

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -85,6 +85,15 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 	settings := s.getSettings()
 	completionCtx := determineCompletionContext(doc, params.Position, params.Context)
 	counts := getCountsForContext(completionCtx, result, settings.Completion)
+
+	var recency map[string]string
+	if completionCtx == ContextAccount {
+		if payee := extractPayeeForCompletion(doc, cursorLine); payee != "" {
+			counts = payeeBoostedCounts(result, payee, counts)
+			recency = payeeRecency(result, payee)
+		}
+	}
+
 	items := s.generateCompletionItems(completionCtx, result, doc, params.Position, counts, settings.Completion)
 	attachResolveData(items, completionCtx, params.TextDocument.URI)
 
@@ -104,7 +113,7 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 
 	query := extractQueryText(doc, params.Position, completionCtx)
 	scored := filterAndScoreFuzzyMatch(items, query, settings.Completion.FuzzyMatching)
-	items = rankCompletionItemsByScore(scored, counts, query)
+	items = rankCompletionItemsByScore(scored, counts, query, recency)
 
 	if settings.Completion.MaxResults > 0 && len(items) > settings.Completion.MaxResults {
 		items = items[:settings.Completion.MaxResults]
@@ -134,7 +143,7 @@ func getCountsForContext(ctxType CompletionContextType, result *analyzer.Analysi
 	}
 }
 
-func rankCompletionItemsByScore(scored []scoredItem, counts map[string]int, query string) []protocol.CompletionItem {
+func rankCompletionItemsByScore(scored []scoredItem, counts map[string]int, query string, recency map[string]string) []protocol.CompletionItem {
 	sort.Slice(scored, func(i, j int) bool {
 		if scored[i].score != scored[j].score {
 			return scored[i].score > scored[j].score
@@ -145,7 +154,13 @@ func rankCompletionItemsByScore(scored []scoredItem, counts map[string]int, quer
 			countI = counts[scored[i].item.Label]
 			countJ = counts[scored[j].item.Label]
 		}
-		return countI > countJ
+		if countI != countJ {
+			return countI > countJ
+		}
+		if recency != nil {
+			return recency[scored[i].item.Label] > recency[scored[j].item.Label]
+		}
+		return false
 	})
 
 	items := make([]protocol.CompletionItem, len(scored))
@@ -155,6 +170,51 @@ func rankCompletionItemsByScore(scored []scoredItem, counts map[string]int, quer
 		items[i].FilterText = query
 	}
 	return items
+}
+
+const payeeBoostMultiplier = 100
+
+func extractPayeeForCompletion(doc string, cursorLine int) string {
+	lines := strings.Split(doc, "\n")
+	for i := cursorLine; i >= 0; i-- {
+		line := lines[i]
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' {
+			continue
+		}
+		if isTransactionHeaderLine(line) {
+			return extractPayeeFromHeader(line)
+		}
+		return ""
+	}
+	return ""
+}
+
+func payeeBoostedCounts(result *analyzer.AnalysisResult, payee string, globalCounts map[string]int) map[string]int {
+	boosted := make(map[string]int, len(globalCounts))
+	for k, v := range globalCounts {
+		boosted[k] = v
+	}
+	prefix := payee + "::"
+	for key, count := range result.PayeeAccountPairUsage {
+		if account, ok := strings.CutPrefix(key, prefix); ok {
+			boosted[account] += count * payeeBoostMultiplier
+		}
+	}
+	return boosted
+}
+
+func payeeRecency(result *analyzer.AnalysisResult, payee string) map[string]string {
+	recency := make(map[string]string)
+	prefix := payee + "::"
+	for key, date := range result.PayeeAccountLastUsed {
+		if account, ok := strings.CutPrefix(key, prefix); ok {
+			recency[account] = date
+		}
+	}
+	return recency
 }
 
 func determineCompletionContext(content string, pos protocol.Position, ctx *protocol.CompletionContext) CompletionContextType {

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -4084,3 +4084,160 @@ func TestCompletion_TagName_Unicode_CalculateRange(t *testing.T) {
 	assert.Equal(t, uint32(22), r.Start.Character, "Unicode: start after '; '")
 	assert.Equal(t, uint32(25), r.End.Character, "Unicode: end at cursor")
 }
+
+func TestCompletion_PayeeAwareAccountRanking(t *testing.T) {
+	srv := NewServer()
+	content := `2024-01-01 Grocery Store
+    expenses:food  $50
+    assets:cash
+
+2024-01-02 Gas Station
+    expenses:fuel  $40
+    assets:cash
+
+2024-01-03 Grocery Store
+    expenses:food  $30
+    assets:cash
+
+2024-01-04 Grocery Store
+    `
+
+	srv.documents.Store(protocol.DocumentURI("file:///test.journal"), content)
+
+	params := &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: "file:///test.journal",
+			},
+			Position: protocol.Position{Line: 13, Character: 4},
+		},
+	}
+
+	result, err := srv.Completion(context.Background(), params)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var foodItem, fuelItem *protocol.CompletionItem
+	for i := range result.Items {
+		if result.Items[i].Label == "expenses:food" {
+			foodItem = &result.Items[i]
+		}
+		if result.Items[i].Label == "expenses:fuel" {
+			fuelItem = &result.Items[i]
+		}
+	}
+
+	require.NotNil(t, foodItem, "expenses:food should be in completion items")
+	require.NotNil(t, fuelItem, "expenses:fuel should be in completion items")
+
+	assert.True(t, foodItem.SortText < fuelItem.SortText,
+		"Payee-associated account expenses:food (SortText=%s) should rank before expenses:fuel (SortText=%s)",
+		foodItem.SortText, fuelItem.SortText)
+}
+
+func TestCompletion_PayeeAwareRanking_UnknownPayeeFallsBackToGlobal(t *testing.T) {
+	srv := NewServer()
+	content := `2024-01-01 Grocery Store
+    expenses:food  $50
+    assets:cash
+
+2024-01-02 Grocery Store
+    expenses:food  $30
+    assets:cash
+
+2024-01-03 Gas Station
+    expenses:fuel  $40
+    assets:cash
+
+2024-01-04 Unknown Place
+    `
+
+	srv.documents.Store(protocol.DocumentURI("file:///test.journal"), content)
+
+	params := &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: "file:///test.journal",
+			},
+			Position: protocol.Position{Line: 13, Character: 4},
+		},
+	}
+
+	result, err := srv.Completion(context.Background(), params)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var foodItem, fuelItem *protocol.CompletionItem
+	for i := range result.Items {
+		if result.Items[i].Label == "expenses:food" {
+			foodItem = &result.Items[i]
+		}
+		if result.Items[i].Label == "expenses:fuel" {
+			fuelItem = &result.Items[i]
+		}
+	}
+
+	require.NotNil(t, foodItem, "expenses:food should be in completion items")
+	require.NotNil(t, fuelItem, "expenses:fuel should be in completion items")
+
+	assert.True(t, foodItem.SortText < fuelItem.SortText,
+		"Unknown payee: globally frequent expenses:food (SortText=%s) should rank before expenses:fuel (SortText=%s)",
+		foodItem.SortText, fuelItem.SortText)
+}
+
+func TestCompletion_PayeeAwareRanking_RecencyTiebreaker(t *testing.T) {
+	srv := NewServer()
+	content := `2024-01-01 Grocery Store
+    expenses:food  $50
+    assets:cash
+
+2024-03-01 Grocery Store
+    expenses:food  $30
+    assets:bank
+
+2024-02-01 Grocery Store
+    expenses:food  $20
+    assets:cash
+
+2024-04-01 Grocery Store
+    expenses:food  $10
+    assets:bank
+
+2024-05-01 Grocery Store
+    `
+
+	srv.documents.Store(protocol.DocumentURI("file:///test.journal"), content)
+
+	params := &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: "file:///test.journal",
+			},
+			Position: protocol.Position{Line: 17, Character: 4},
+		},
+	}
+
+	result, err := srv.Completion(context.Background(), params)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var cashItem, bankItem *protocol.CompletionItem
+	for i := range result.Items {
+		if result.Items[i].Label == "assets:cash" {
+			cashItem = &result.Items[i]
+		}
+		if result.Items[i].Label == "assets:bank" {
+			bankItem = &result.Items[i]
+		}
+	}
+
+	require.NotNil(t, cashItem, "assets:cash should be in completion items")
+	require.NotNil(t, bankItem, "assets:bank should be in completion items")
+
+	// Both have payee pair usage count 2 for "Grocery Store".
+	// assets:cash last used 2024-02-01, assets:bank last used 2024-04-01.
+	// Recency tiebreaker: bank is more recent.
+	assert.True(t, bankItem.SortText < cashItem.SortText,
+		"More recently used assets:bank (SortText=%s) should rank before assets:cash (SortText=%s)",
+		bankItem.SortText, cashItem.SortText)
+}

--- a/internal/server/inline_completion.go
+++ b/internal/server/inline_completion.go
@@ -85,8 +85,8 @@ func (s *Server) InlineCompletion(_ context.Context, params json.RawMessage) (*I
 	}
 
 	templates := s.getPayeeTemplates(p.TextDocument.URI, content)
-	postings, ok := templates[payee]
-	if !ok || len(postings) == 0 {
+	postings, ok := fuzzyMatchPayeeTemplate(templates, payee)
+	if !ok {
 		return &InlineCompletionList{Items: []InlineCompletionItem{}}, nil
 	}
 
@@ -129,6 +129,32 @@ func (s *Server) getPayeeTemplates(uri protocol.DocumentURI, content string) map
 
 	s.payeeTemplatesCache.Store(uri, result.PayeeTemplates)
 	return result.PayeeTemplates
+}
+
+func fuzzyMatchPayeeTemplate(templates map[string][]analyzer.PostingTemplate, payee string) ([]analyzer.PostingTemplate, bool) {
+	if postings, ok := templates[payee]; ok && len(postings) > 0 {
+		return postings, true
+	}
+
+	bestScore := 0
+	var bestKey string
+	for key := range templates {
+		if score := fuzzyMatchScore(key, payee); score > bestScore {
+			bestScore = score
+			bestKey = key
+		}
+	}
+
+	minScore := fuzzyScoreBaseMatch * max(3, utf8.RuneCountInString(payee)/2)
+	if bestScore < minScore || bestKey == "" {
+		return nil, false
+	}
+
+	postings := templates[bestKey]
+	if len(postings) == 0 {
+		return nil, false
+	}
+	return postings, true
 }
 
 func isTransactionHeaderLine(line string) bool {

--- a/internal/server/inline_completion_test.go
+++ b/internal/server/inline_completion_test.go
@@ -858,3 +858,102 @@ func TestInlineCompletion_DeterministicWithMultiplePatterns(t *testing.T) {
 		"Should select pattern from last transaction when counts are equal")
 	assert.Contains(t, firstResult, "assets:wallet")
 }
+
+func TestInlineCompletion_FuzzyPayeeMatch(t *testing.T) {
+	srv := NewServer()
+
+	settings := srv.getSettings()
+	settings.Features.InlineCompletion = true
+	srv.setSettings(settings)
+
+	content := `2024-01-10 Grocery Store
+    expenses:food  $50.00
+    assets:cash
+
+2024-01-15 Grcery Store
+`
+	uri := protocol.DocumentURI("file:///test.journal")
+	srv.documents.Store(uri, content)
+
+	params := InlineCompletionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position:     protocol.Position{Line: 5, Character: 0},
+		Context:      InlineCompletionContext{TriggerKind: InlineCompletionTriggerAutomatic},
+	}
+
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, err := srv.InlineCompletion(context.Background(), paramsJSON)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Items, 1, "fuzzy match should find template for misspelled payee")
+
+	assert.Contains(t, result.Items[0].InsertText, "expenses:food")
+	assert.Contains(t, result.Items[0].InsertText, "assets:cash")
+}
+
+func TestInlineCompletion_FuzzyPayeeMatch_NoMatchForUnrelated(t *testing.T) {
+	srv := NewServer()
+
+	settings := srv.getSettings()
+	settings.Features.InlineCompletion = true
+	srv.setSettings(settings)
+
+	content := `2024-01-10 Grocery Store
+    expenses:food  $50.00
+    assets:cash
+
+2024-01-15 xyz
+`
+	uri := protocol.DocumentURI("file:///test.journal")
+	srv.documents.Store(uri, content)
+
+	params := InlineCompletionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position:     protocol.Position{Line: 5, Character: 0},
+		Context:      InlineCompletionContext{TriggerKind: InlineCompletionTriggerAutomatic},
+	}
+
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, err := srv.InlineCompletion(context.Background(), paramsJSON)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Empty(t, result.Items, "should not match unrelated short payee")
+}
+
+func TestInlineCompletion_FuzzyPayeeMatch_Unicode(t *testing.T) {
+	srv := NewServer()
+
+	settings := srv.getSettings()
+	settings.Features.InlineCompletion = true
+	srv.setSettings(settings)
+
+	content := `2024-01-10 Пятёрочка
+    expenses:food  $50.00
+    assets:cash
+
+2024-01-15 Пятёрочка
+`
+	uri := protocol.DocumentURI("file:///test.journal")
+	srv.documents.Store(uri, content)
+
+	params := InlineCompletionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position:     protocol.Position{Line: 5, Character: 0},
+		Context:      InlineCompletionContext{TriggerKind: InlineCompletionTriggerAutomatic},
+	}
+
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, err := srv.InlineCompletion(context.Background(), paramsJSON)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Items, 1, "exact unicode payee match should work")
+
+	assert.Contains(t, result.Items[0].InsertText, "expenses:food")
+}


### PR DESCRIPTION
Closes #41.

## Summary

Extends the existing payee→account history infrastructure to the interactive editor flow:

1. **Payee-aware account ranking in completion** — when completing an account inside a transaction whose payee is known, accounts from that payee's history get a ×100 boost over global frequency. Unknown payee falls back to unchanged global ranking.

2. **Recency weighting** — new `PayeeAccountLastUsed` field in `AnalysisResult` tracks the latest date per payee::account pair. When fuzzy score and boosted count are equal, the more recently used account ranks first.

3. **Fuzzy payee matching for inline templates** — exact payee lookup replaced with subsequence fuzzy matching (reusing the existing `fuzzyMatchScore`), so typos like "Grcery Store" still surface the "Grocery Store" ghost text. Short unrelated payees are rejected by a length-proportional threshold.

## Changes

| File | What |
|------|------|
| `internal/analyzer/types.go` | `PayeeAccountLastUsed map[string]string` in `AnalysisResult` |
| `internal/analyzer/payee_accounts.go` | `CollectPayeeAccountLastUsed` + resolved variant |
| `internal/analyzer/analyzer.go` | Wire new field in `Analyze` / `AnalyzeResolved` |
| `internal/server/completion.go` | `extractPayeeForCompletion`, `payeeBoostedCounts`, `payeeRecency`; recency tiebreaker in `rankCompletionItemsByScore` |
| `internal/server/inline_completion.go` | `fuzzyMatchPayeeTemplate` replaces exact map lookup |

## Verification

- `go test -race ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues
- 10 new tests: payee-aware ranking, unknown-payee fallback, recency tiebreaker, fuzzy match, no false positive, unicode