### PR TITLE
perf(server): optimize request path with parse cache and rope edits (#35)

### DIFF
--- a/internal/benchmark/nfr_test.go
+++ b/internal/benchmark/nfr_test.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
 	"go.lsp.dev/protocol"
 
+	"github.com/juev/hledger-lsp/internal/document"
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/parser"
 	"github.com/juev/hledger-lsp/internal/server"
@@ -162,5 +164,153 @@ func TestNFR_1_4_MemoryUsage(t *testing.T) {
 		t.Errorf("NFR-1.4: Memory usage should be < 200MB, got %dMB", usedMB)
 	} else {
 		t.Logf("NFR-1.4 PASS: Memory usage is %dMB (target: < 200MB)", usedMB)
+	}
+}
+
+// newBenchmarkServerWithWorkspace initializes a server in workspace-folder mode
+// so DidChange exercises the real hot path (UpdateFileWithJournal + include
+// resolution) rather than the no-workspace fallback.
+func newBenchmarkServerWithWorkspace(t *testing.T, dir string) *server.Server {
+	t.Helper()
+	srv := server.NewServer()
+	if _, err := srv.Initialize(context.Background(), &protocol.InitializeParams{
+		WorkspaceFolders: []protocol.WorkspaceFolder{{URI: "file://" + dir, Name: "bench"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.Initialized(context.Background(), &protocol.InitializedParams{}); err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+// TestNFR_PerKeystrokeCycle measures one DidChange (incremental edit) followed by
+// a Completion request in workspace mode. DidChange parses the edited content
+// once (UpdateFileWithJournal reuses the cached journal); Completion reuses that
+// cached journal instead of reparsing.
+func TestNFR_PerKeystrokeCycle(t *testing.T) {
+	for _, n := range []int{1000, 10000} {
+		t.Run(fmt.Sprintf("%dtx", n), func(t *testing.T) {
+			content := testutil.GenerateJournal(n)
+			tmpDir := t.TempDir()
+			mainPath, err := writeJournalFile(tmpDir, "main.journal", content)
+			if err != nil {
+				t.Fatal(err)
+			}
+			srv := newBenchmarkServerWithWorkspace(t, tmpDir)
+			docURI := protocol.DocumentURI("file://" + mainPath)
+			srv.StoreDocument(docURI, content)
+
+			completionParams := &protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+					Position:     protocol.Position{Line: 1, Character: 4},
+				},
+			}
+
+			const iterations = 50
+			start := time.Now()
+			for range iterations {
+				// Incremental insert at line 1 (NOT {0,0}-{0,0}, which the server
+				// treats as a full-document replace). Keeps the document large so
+				// each keystroke does a real parse of the whole journal.
+				change := protocol.TextDocumentContentChangeEvent{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 0},
+					},
+					Text: "; k\n",
+				}
+				_ = srv.DidChange(context.Background(), &protocol.DidChangeTextDocumentParams{
+					TextDocument: protocol.VersionedTextDocumentIdentifier{
+						TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: docURI},
+					},
+					ContentChanges: []protocol.TextDocumentContentChangeEvent{change},
+				})
+				_, _ = srv.Completion(context.Background(), completionParams)
+			}
+			avg := time.Since(start) / iterations
+
+			limit := 50 * time.Millisecond
+			if n >= 10000 {
+				limit = 200 * time.Millisecond
+			}
+			if avg >= limit {
+				t.Errorf("NFR per-keystroke cycle (%d tx) should be < %v, got %v", n, limit, avg)
+			} else {
+				t.Logf("NFR per-keystroke cycle PASS (%d tx): %v avg (DidChange + Completion, target < %v)", n, avg, limit)
+			}
+		})
+	}
+}
+
+// TestNFR_RepeatedRequestReusesCache verifies that repeated requests for an
+// unchanged document reuse the cached parse: the first (cold) request parses the
+// 10k-transaction document, subsequent (warm) requests skip the parse.
+func TestNFR_RepeatedRequestReusesCache(t *testing.T) {
+	content := testutil.GenerateJournal(10000)
+	srv := server.NewServer()
+	docURI := protocol.DocumentURI("file:///test.journal")
+	srv.StoreDocument(docURI, content)
+
+	hoverParams := &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+			Position:     protocol.Position{Line: 1, Character: 6},
+		},
+	}
+
+	coldStart := time.Now()
+	_, _ = srv.Hover(context.Background(), hoverParams)
+	cold := time.Since(coldStart)
+
+	const iterations = 100
+	warmStart := time.Now()
+	for range iterations {
+		_, _ = srv.Hover(context.Background(), hoverParams)
+	}
+	warmAvg := time.Since(warmStart) / iterations
+
+	t.Logf("NFR cache reuse (10k tx): cold first hover %v, warm avg %v over %d iterations", cold, warmAvg, iterations)
+	if warmAvg >= cold {
+		t.Errorf("NFR cache reuse: warm avg (%v) should be faster than cold first request (%v)", warmAvg, cold)
+	} else {
+		t.Logf("NFR cache reuse PASS: warm avg %v < cold %v", warmAvg, cold)
+	}
+}
+
+// TestNFR_ApplyChangeSubLinear verifies criterion 4: applying an edit to the
+// document rope does not scale with the total line count. A single-character
+// insert in the middle of a 10k-transaction journal must not be ~10x slower than
+// the same edit on a 1k-transaction journal (the rope edit is O(log n) in lines).
+func TestNFR_ApplyChangeSubLinear(t *testing.T) {
+	measure := func(transactions int) time.Duration {
+		content := testutil.GenerateJournal(transactions)
+		lineCount := strings.Count(content, "\n") + 1
+		mid := uint32(lineCount / 2)
+		r := protocol.Range{
+			Start: protocol.Position{Line: mid, Character: 0},
+			End:   protocol.Position{Line: mid, Character: 0},
+		}
+		nt := document.NewText(content)
+
+		const iterations = 500
+		start := time.Now()
+		for range iterations {
+			nt.ApplyChange(r, "x")
+		}
+		return time.Since(start) / iterations
+	}
+
+	small := measure(1000)
+	large := measure(10000)
+	t.Logf("NFR ApplyChange sub-linear: 1k=%v, 10k=%v (ratio %.2fx)", small, large, float64(large)/float64(small))
+
+	// 10x more lines must not mean 10x slower edits; allow generous headroom for
+	// measurement noise while still catching a linear (O(n)) regression.
+	if large > small*6 {
+		t.Errorf("NFR ApplyChange: 10k (%v) more than 6x slower than 1k (%v); expected sub-linear", large, small)
+	} else {
+		t.Logf("NFR ApplyChange sub-linear PASS: 10k/1k ratio %.2fx (< 6x)", float64(large)/float64(small))
 	}
 }

--- a/internal/document/text.go
+++ b/internal/document/text.go
@@ -1,0 +1,219 @@
+// Package document provides an incremental text buffer for LSP editing.
+//
+// Text is a rope of lines backed by an implicit treap: applying an LSP
+// incremental change and accessing a line by index are O(log n) in the number
+// of lines, instead of re-splitting the whole document on every keystroke (the
+// pathology of building a full position mapper per edit). Materializing the full
+// string via String is O(n) and cached until the next edit; the LSP server still
+// needs the flat string for the string-based parser, so materialization happens
+// once per edit, not per request.
+//
+// Text assumes LF-only input: NewText normalizes CRLF/CR to LF, matching the
+// server's ingestion invariant.
+package document
+
+import (
+	"math/rand"
+	"strings"
+
+	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/lsputil"
+)
+
+// node is one line in an implicit treap ordered by line index. size is the
+// number of lines in the subtree; it drives index-based split and select.
+type node struct {
+	line     string
+	priority uint32
+	size     int
+	left     *node
+	right    *node
+}
+
+func newNode(line string) *node {
+	return &node{line: line, priority: rand.Uint32(), size: 1}
+}
+
+func size(n *node) int {
+	if n == nil {
+		return 0
+	}
+	return n.size
+}
+
+func update(n *node) {
+	if n != nil {
+		n.size = 1 + size(n.left) + size(n.right)
+	}
+}
+
+// split partitions t into (a, b) where a holds the first k lines.
+func split(t *node, k int) (*node, *node) {
+	if t == nil {
+		return nil, nil
+	}
+	if size(t.left) >= k {
+		a, b := split(t.left, k)
+		t.left = b
+		update(t)
+		return a, t
+	}
+	a, b := split(t.right, k-size(t.left)-1)
+	t.right = a
+	update(t)
+	return t, b
+}
+
+// merge concatenates a and b, where every line of a precedes every line of b.
+func merge(a, b *node) *node {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.priority > b.priority {
+		a.right = merge(a.right, b)
+		update(a)
+		return a
+	}
+	b.left = merge(a, b.left)
+	update(b)
+	return b
+}
+
+// Text is an editable, line-indexed rope. The zero value is not usable; create
+// one with NewText.
+type Text struct {
+	root   *node
+	cached *string
+}
+
+// NewText builds a Text from content, normalizing CRLF/CR line endings to LF.
+func NewText(content string) *Text {
+	content = normalizeLF(content)
+	t := &Text{}
+	for _, line := range strings.Split(content, "\n") {
+		t.root = merge(t.root, newNode(line))
+	}
+	return t
+}
+
+func normalizeLF(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\r", "\n")
+}
+
+// LineCount returns the number of lines.
+func (t *Text) LineCount() int {
+	return size(t.root)
+}
+
+// Line returns the i-th line (without its trailing newline), or "" if i is out
+// of range. O(log n).
+func (t *Text) Line(i int) string {
+	if i < 0 {
+		return ""
+	}
+	n := t.root
+	for n != nil {
+		leftSize := size(n.left)
+		switch {
+		case i < leftSize:
+			n = n.left
+		case i == leftSize:
+			return n.line
+		default:
+			i -= leftSize + 1
+			n = n.right
+		}
+	}
+	return ""
+}
+
+// String materializes the full document. O(n), cached until the next ApplyChange.
+func (t *Text) String() string {
+	if t.cached != nil {
+		return *t.cached
+	}
+	var sb strings.Builder
+	first := true
+	var walk func(n *node)
+	walk = func(n *node) {
+		if n == nil {
+			return
+		}
+		walk(n.left)
+		if !first {
+			sb.WriteByte('\n')
+		}
+		first = false
+		sb.WriteString(n.line)
+		walk(n.right)
+	}
+	walk(t.root)
+	s := sb.String()
+	t.cached = &s
+	return s
+}
+
+// ApplyChange applies an LSP incremental edit in place. The replaced range is
+// given in UTF-16 line/character coordinates; text may contain newlines. The
+// edit itself is O(log n) in the line count plus O(len(text)); the cached
+// materialized string is invalidated.
+func (t *Text) ApplyChange(r protocol.Range, text string) {
+	t.cached = nil
+	lineCount := size(t.root)
+	if lineCount == 0 {
+		for _, line := range strings.Split(text, "\n") {
+			t.root = merge(t.root, newNode(line))
+		}
+		return
+	}
+
+	// Resolve an endpoint to a (line, byteOffset) within the document, matching
+	// lsputil.PositionMapper.LSPToByte: a line beyond the last maps to the end of
+	// the document (end of the last line, character offset ignored) rather than
+	// clamping into the last line, which would corrupt the buffer.
+	resolve := func(line, char uint32) (int, int) {
+		if int(line) >= lineCount {
+			last := t.Line(lineCount - 1)
+			return lineCount - 1, len(last)
+		}
+		l := t.Line(int(line))
+		b := lsputil.UTF16OffsetToByteOffset(l, int(char))
+		if b > len(l) {
+			b = len(l)
+		}
+		return int(line), b
+	}
+
+	sl, scBytes := resolve(r.Start.Line, r.Start.Character)
+	el, ecBytes := resolve(r.End.Line, r.End.Character)
+
+	// Normalize an inverted range (start after end) to LSP splice semantics,
+	// comparing absolute document order (line, then byte offset within the line).
+	if sl > el || (sl == el && scBytes > ecBytes) {
+		sl, el = el, sl
+		scBytes, ecBytes = ecBytes, scBytes
+	}
+
+	startLine := t.Line(sl)
+	endLine := t.Line(el)
+
+	prefix := startLine[:scBytes]
+	suffix := endLine[ecBytes:]
+	newLines := strings.Split(prefix+text+suffix, "\n")
+
+	// A = lines[0..sl-1], drop lines[sl..el], D = lines[el+1..].
+	A, rest := split(t.root, sl)
+	_, D := split(rest, el-sl+1)
+
+	var M *node
+	for _, line := range newLines {
+		M = merge(M, newNode(line))
+	}
+
+	t.root = merge(A, merge(M, D))
+}

--- a/internal/document/text_bench_test.go
+++ b/internal/document/text_bench_test.go
@@ -1,0 +1,51 @@
+package document
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.lsp.dev/protocol"
+)
+
+func buildJournalLines(transactions int) string {
+	var sb strings.Builder
+	for i := 0; i < transactions; i++ {
+		fmt.Fprintf(&sb, "2024-01-01 * Payee %d | note\n", i)
+		fmt.Fprintf(&sb, "    expenses:acct%d  $%d.00\n", i%10, i+1)
+		sb.WriteString("    assets:cash\n")
+	}
+	return sb.String()
+}
+
+// BenchmarkTextApplyChange measures the edit-application cost (ApplyChange only;
+// the O(n) build happens once, outside the timer) at 1k and 10k transactions. A
+// sub-linear O(log n) edit stays roughly flat across the two sizes. Edits
+// alternate insert/delete at the same position so the document stays bounded.
+func BenchmarkTextApplyChange(b *testing.B) {
+	for _, n := range []int{1000, 10000} {
+		b.Run(fmt.Sprintf("%dtx", n), func(b *testing.B) {
+			content := buildJournalLines(n)
+			lineCount := strings.Count(content, "\n") + 1
+			mid := uint32(lineCount / 2)
+			insert := protocol.Range{
+				Start: protocol.Position{Line: mid, Character: 0},
+				End:   protocol.Position{Line: mid, Character: 0},
+			}
+			del := protocol.Range{
+				Start: protocol.Position{Line: mid, Character: 0},
+				End:   protocol.Position{Line: mid, Character: 1},
+			}
+			nt := NewText(content)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if i%2 == 0 {
+					nt.ApplyChange(insert, "x")
+				} else {
+					nt.ApplyChange(del, "")
+				}
+			}
+		})
+	}
+}

--- a/internal/document/text_test.go
+++ b/internal/document/text_test.go
@@ -1,0 +1,290 @@
+package document
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/lsputil"
+)
+
+// oracleApply applies an LSP change using the reference PositionMapper.
+func oracleApply(content string, r protocol.Range, text string) string {
+	return lsputil.NewPositionMapper(content).ApplyChange(r, text)
+}
+
+func TestText_StringRoundTrip(t *testing.T) {
+	for _, content := range []string{
+		"",
+		"a",
+		"a\nb\nc",
+		"a\nb\nc\n",
+		"\n\n",
+		"2024-01-01 * store\n    expenses:food  $50\n    assets:cash\n",
+	} {
+		nt := NewText(content)
+		if got := nt.String(); got != content {
+			t.Fatalf("round-trip mismatch for %q: got %q", content, got)
+		}
+	}
+}
+
+func TestText_CRLFNormalized(t *testing.T) {
+	nt := NewText("a\r\nb\r\nc")
+	if got := nt.String(); got != "a\nb\nc" {
+		t.Fatalf("CRLF not normalized: %q", got)
+	}
+	nt2 := NewText("a\rb\rc")
+	if got := nt2.String(); got != "a\nb\nc" {
+		t.Fatalf("lone CR not normalized: %q", got)
+	}
+}
+
+func TestText_LineAndCount(t *testing.T) {
+	nt := NewText("a\nbb\nccc")
+	if nt.LineCount() != 3 {
+		t.Fatalf("LineCount = %d, want 3", nt.LineCount())
+	}
+	if nt.Line(0) != "a" || nt.Line(1) != "bb" || nt.Line(2) != "ccc" {
+		t.Fatalf("Line mismatch: %q %q %q", nt.Line(0), nt.Line(1), nt.Line(2))
+	}
+	if nt.Line(3) != "" || nt.Line(-1) != "" {
+		t.Fatalf("out-of-range Line should be empty, got %q / %q", nt.Line(3), nt.Line(-1))
+	}
+}
+
+func TestText_ApplyChange_InsertSingleChar(t *testing.T) {
+	nt := NewText("hello world")
+	nt.ApplyChange(protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 5},
+		End:   protocol.Position{Line: 0, Character: 5},
+	}, ",")
+	if got := nt.String(); got != "hello, world" {
+		t.Fatalf("got %q, want %q", got, "hello, world")
+	}
+}
+
+func TestText_ApplyChange_MultiLineInsert(t *testing.T) {
+	nt := NewText("ab")
+	nt.ApplyChange(protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 1},
+		End:   protocol.Position{Line: 0, Character: 1},
+	}, "X\nY\nZ")
+	if got := nt.String(); got != "aX\nY\nZb" {
+		t.Fatalf("got %q, want %q", got, "aX\nY\nZb")
+	}
+	if nt.LineCount() != 3 {
+		t.Fatalf("LineCount = %d, want 3", nt.LineCount())
+	}
+}
+
+func TestText_ApplyChange_DeleteAcrossLines(t *testing.T) {
+	nt := NewText("line1\nline2\nline3")
+	// Delete from line0 char2 to line2 char2 → "li" + "ne3" = "line3".
+	nt.ApplyChange(protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 2},
+		End:   protocol.Position{Line: 2, Character: 2},
+	}, "")
+	if got := nt.String(); got != "line3" {
+		t.Fatalf("got %q, want %q", got, "line3")
+	}
+}
+
+func TestText_ApplyChange_ReplaceWholeDocument(t *testing.T) {
+	nt := NewText("old\ncontent")
+	last := nt.LineCount() - 1
+	lastLen := lsputil.UTF16Len(nt.Line(last))
+	nt.ApplyChange(protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 0},
+		End:   protocol.Position{Line: uint32(last), Character: uint32(lastLen)},
+	}, "brand\nnew\ntext")
+	if got := nt.String(); got != "brand\nnew\ntext" {
+		t.Fatalf("got %q, want %q", got, "brand\nnew\ntext")
+	}
+}
+
+func TestText_ApplyChange_UTF16EmojiAndCJK(t *testing.T) {
+	// "💶" is a surrogate pair (2 UTF-16 units, 4 bytes); "日" is 1 unit, 3 bytes.
+	nt := NewText("a💶日b")
+	// Insert after the emoji: UTF-16 offset 3 (a=1, 💶=2).
+	nt.ApplyChange(protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 3},
+		End:   protocol.Position{Line: 0, Character: 3},
+	}, "X")
+	if got := nt.String(); got != "a💶X日b" {
+		t.Fatalf("got %q, want %q", got, "a💶X日b")
+	}
+}
+
+func TestText_ApplyChange_InvalidatesCachedString(t *testing.T) {
+	nt := NewText("abc")
+	before := nt.String()
+	nt.ApplyChange(protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 3},
+		End:   protocol.Position{Line: 0, Character: 3},
+	}, "d")
+	after := nt.String()
+	if before != "abc" || after != "abcd" {
+		t.Fatalf("cache not invalidated: before=%q after=%q", before, after)
+	}
+}
+
+func TestText_ApplyChange_OutOfRangeNoPanic(t *testing.T) {
+	nt := NewText("abc\ndef")
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on out-of-range change: %v", r)
+		}
+	}()
+	nt.ApplyChange(protocol.Range{
+		Start: protocol.Position{Line: 99, Character: 99},
+		End:   protocol.Position{Line: 100, Character: 0},
+	}, "x")
+	_ = nt.String()
+}
+
+func pos(line, char uint32) protocol.Position {
+	return protocol.Position{Line: line, Character: char}
+}
+
+// TestText_ApplyChange_OutOfRangeMatchesOracle pins the regression where a line
+// beyond the last was clamped INTO the last line (corrupting the buffer) instead
+// of mapping to end-of-document like lsputil.PositionMapper.LSPToByte.
+func TestText_ApplyChange_OutOfRangeMatchesOracle(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		r       protocol.Range
+		text    string
+	}{
+		{"line-beyond-insert", "abc", protocol.Range{Start: pos(5, 0), End: pos(5, 0)}, "X"},
+		{"line-beyond-char", "abc", protocol.Range{Start: pos(5, 2), End: pos(5, 2)}, "X"},
+		{"end-line-beyond", "a\nb\nc", protocol.Range{Start: pos(1, 0), End: pos(99, 0)}, "X"},
+		{"both-beyond", "abc\ndef", protocol.Range{Start: pos(99, 99), End: pos(100, 0)}, "x"},
+	}
+	for _, tc := range cases {
+		want := oracleApply(tc.content, tc.r, tc.text)
+		nt := NewText(tc.content)
+		nt.ApplyChange(tc.r, tc.text)
+		if got := nt.String(); got != want {
+			t.Fatalf("%s: content=%q range=%+v text=%q want=%q got=%q", tc.name, tc.content, tc.r, tc.text, want, got)
+		}
+	}
+}
+
+func TestText_ApplyChange_OutOfRangeRandomMatchesOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(99))
+	alphabet := []rune("ab \n日💶")
+	for iter := 0; iter < 3000; iter++ {
+		n := rng.Intn(30)
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		content := sb.String()
+		lineCount := len(strings.Split(content, "\n"))
+
+		m := rng.Intn(8)
+		var isb strings.Builder
+		for i := 0; i < m; i++ {
+			isb.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		insert := isb.String()
+
+		// Positions may overshoot the document (line and char beyond the end).
+		r := protocol.Range{
+			Start: pos(uint32(rng.Intn(lineCount+5)), uint32(rng.Intn(20))),
+			End:   pos(uint32(rng.Intn(lineCount+5)), uint32(rng.Intn(20))),
+		}
+
+		want := oracleApply(content, r, insert)
+		nt := NewText(content)
+		nt.ApplyChange(r, insert)
+		if got := nt.String(); got != want {
+			t.Fatalf("iter %d: content=%q range=%+v insert=%q want=%q got=%q", iter, content, r, insert, want, got)
+		}
+	}
+}
+
+// randomRange builds an LSP range with positions valid for content.
+func randomRange(rng *rand.Rand, content string) protocol.Range {
+	lines := strings.Split(content, "\n")
+	lineCount := len(lines)
+	sl := rng.Intn(lineCount)
+	el := rng.Intn(lineCount)
+	if sl > el {
+		sl, el = el, sl
+	}
+	sc := rng.Intn(lsputil.UTF16Len(lines[sl]) + 1)
+	ec := rng.Intn(lsputil.UTF16Len(lines[el]) + 1)
+	return protocol.Range{
+		Start: protocol.Position{Line: uint32(sl), Character: uint32(sc)},
+		End:   protocol.Position{Line: uint32(el), Character: uint32(ec)},
+	}
+}
+
+func TestText_ApplyChange_MatchesOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	// Alphabet spans ASCII, CJK, Cyrillic and a supplementary-plane emoji
+	// (surrogate pair in UTF-16) to exercise UTF-16 column mapping.
+	alphabet := []rune("ab$ \n\texpenses:cash日本語рубль💶")
+
+	for iter := 0; iter < 3000; iter++ {
+		n := rng.Intn(40)
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		content := sb.String()
+
+		m := rng.Intn(10)
+		var isb strings.Builder
+		for i := 0; i < m; i++ {
+			isb.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		insert := isb.String()
+
+		r := randomRange(rng, content)
+
+		want := oracleApply(content, r, insert)
+
+		nt := NewText(content)
+		nt.ApplyChange(r, insert)
+		got := nt.String()
+
+		if got != want {
+			t.Fatalf("iter %d: mismatch\ncontent=%q\nrange=%+v\ninsert=%q\nwant=%q\ngot=%q",
+				iter, content, r, insert, want, got)
+		}
+	}
+}
+
+// TestText_ApplyChange_SequentialEdits applies a sequence of edits, re-deriving
+// each range from the current content, and checks the rope stays consistent with
+// the oracle after every step.
+func TestText_ApplyChange_SequentialEdits(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	alphabet := []rune("xy \n日本語💶")
+
+	content := "start\nmiddle\nend"
+	nt := NewText(content)
+
+	for step := 0; step < 500; step++ {
+		m := rng.Intn(6)
+		var isb strings.Builder
+		for i := 0; i < m; i++ {
+			isb.WriteRune(alphabet[rng.Intn(len(alphabet))])
+		}
+		insert := isb.String()
+		r := randomRange(rng, content)
+
+		content = oracleApply(content, r, insert)
+		nt.ApplyChange(r, insert)
+
+		if got := nt.String(); got != content {
+			t.Fatalf("step %d: divergence\nwant=%q\ngot=%q", step, content, got)
+		}
+	}
+}

--- a/internal/include/loader.go
+++ b/internal/include/loader.go
@@ -88,6 +88,17 @@ func (l *Loader) LoadFromContent(path, content string) (*ResolvedJournal, []Load
 	}})
 }
 
+// FileSizeError returns a file-too-large LoadError when content exceeds the
+// configured MaxFileSizeBytes, or nil when it fits. It lets callers guard the
+// analyze path before parsing.
+func (l *Loader) FileSizeError(content string) *LoadError {
+	limits := l.getLimits()
+	if int64(len(content)) > limits.MaxFileSizeBytes {
+		return &LoadError{Kind: ErrorFileTooLarge, Message: fmt.Sprintf("file too large: %d bytes (max %d)", len(content), limits.MaxFileSizeBytes)}
+	}
+	return nil
+}
+
 func (l *Loader) load(path, content string, options LoadOptions) (*ResolvedJournal, []LoadError) {
 	result := NewResolvedJournal(nil)
 	result.Items = make([]ResolvedItem, 0)

--- a/internal/include/loader_test.go
+++ b/internal/include/loader_test.go
@@ -502,6 +502,46 @@ func TestLoader_MaxFileSizeLimit(t *testing.T) {
 	}
 }
 
+func TestLoader_FileSizeError(t *testing.T) {
+	loader := NewLoader()
+	loader.SetLimits(Limits{
+		MaxFileSizeBytes: 10,
+		MaxIncludeDepth:  defaultMaxIncludeDepth,
+	})
+
+	tests := []struct {
+		name    string
+		content string
+		wantNil bool
+	}{
+		{name: "under limit", content: "12345", wantNil: true},
+		{name: "at limit boundary", content: "1234567890", wantNil: true},
+		{name: "over limit", content: "12345678901", wantNil: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := loader.FileSizeError(tt.content)
+			if tt.wantNil {
+				if err != nil {
+					t.Fatalf("expected nil for content len %d, got: %v", len(tt.content), err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected file too large error for content len %d, got nil", len(tt.content))
+			}
+			if err.Kind != ErrorFileTooLarge {
+				t.Fatalf("expected Kind=ErrorFileTooLarge, got %v", err.Kind)
+			}
+			wantMsg := "file too large: 11 bytes (max 10)"
+			if err.Message != wantMsg {
+				t.Fatalf("expected message %q, got %q", wantMsg, err.Message)
+			}
+		})
+	}
+}
+
 func TestLoader_MaxIncludeDepthLimit(t *testing.T) {
 	dir := t.TempDir()
 	mainFile := filepath.Join(dir, "main.journal")

--- a/internal/server/analyze_cache_test.go
+++ b/internal/server/analyze_cache_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func TestAnalyze_ReusesCachedJournalAndPreservesDiagnostics(t *testing.T) {
+	srv := NewServer()
+	uri := protocol.DocumentURI("file:///a.journal")
+	path := uriToPath(uri)
+
+	// Content with an unterminated comment block: analyze must surface the
+	// parse-error diagnostic (now sourced from the shared cache parse).
+	content := "comment\nunterminated block\n"
+
+	warm := srv.cachedParse(uri, content)
+	require.NotNil(t, warm.journal)
+
+	diags := srv.analyze(uri, path, content)
+
+	require.NotEmpty(t, diags, "analyze must surface the parse-error diagnostic")
+	found := false
+	for _, d := range diags {
+		if d.Source == "hledger-lsp" && strings.Contains(d.Message, "unterminated") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected an 'unterminated' parse diagnostic, got: %+v", diags)
+
+	// The cache entry is unchanged: analyze reused it rather than parsing anew.
+	after := srv.cachedParse(uri, content)
+	assert.Same(t, warm.journal, after.journal, "analyze must reuse the cached journal")
+}

--- a/internal/server/code_action.go
+++ b/internal/server/code_action.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juev/hledger-lsp/internal/formatter"
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/lsputil"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 type hledgerCommand struct {
@@ -73,7 +72,7 @@ func (s *Server) getQuickFixCodeActions(params *protocol.CodeActionParams) []pro
 		var action protocol.CodeAction
 		switch fmt.Sprint(diag.Code) {
 		case "UNBALANCED":
-			journal, _ := parser.Parse(doc)
+			journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 			if journal == nil {
 				continue
 			}
@@ -124,7 +123,7 @@ func (s *Server) quickFixDiagnostics(params *protocol.CodeActionParams, doc stri
 		return filtered
 	}
 
-	diagnostics := s.analyze(uriToPath(params.TextDocument.URI), doc)
+	diagnostics := s.analyze(params.TextDocument.URI, uriToPath(params.TextDocument.URI), doc)
 	filtered := make([]protocol.Diagnostic, 0, len(diagnostics))
 	for _, diag := range diagnostics {
 		if !isQuickFixableCode(fmt.Sprint(diag.Code)) {
@@ -315,7 +314,7 @@ func (s *Server) executeFixUnbalanced(ctx context.Context, params *protocol.Exec
 	if !ok {
 		return nil, fmt.Errorf("document not open")
 	}
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(uri, doc)
 	if journal == nil {
 		return nil, fmt.Errorf("failed to parse document")
 	}

--- a/internal/server/codelens.go
+++ b/internal/server/codelens.go
@@ -10,7 +10,6 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/analyzer"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func (s *Server) CodeLens(_ context.Context, params *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
@@ -24,7 +23,7 @@ func (s *Server) CodeLens(_ context.Context, params *protocol.CodeLensParams) ([
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	if len(journal.Transactions) == 0 {
 		return nil, nil
 	}

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juev/hledger-lsp/internal/analyzer"
 	"github.com/juev/hledger-lsp/internal/filetype"
 	"github.com/juev/hledger-lsp/internal/lsputil"
-	"github.com/juev/hledger-lsp/internal/parser"
 	"github.com/juev/hledger-lsp/internal/rules"
 )
 
@@ -76,7 +75,7 @@ func (s *Server) Completion(ctx context.Context, params *protocol.CompletionPara
 		filtered := resolvedWithoutTransaction(resolved, cursorLine, params.TextDocument.URI)
 		result = s.analyzer.AnalyzeResolved(filtered)
 	} else {
-		journal, _ := parser.Parse(doc)
+		journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 		txIdx := findCurrentTransactionIndex(journal.Transactions, cursorLine)
 		filtered := journalWithoutTransaction(journal, txIdx)
 		result = s.analyzer.Analyze(filtered)

--- a/internal/server/completion_resolve.go
+++ b/internal/server/completion_resolve.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/analyzer"
 	"github.com/juev/hledger-lsp/internal/ast"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 type completionResolveData struct {
@@ -79,7 +78,7 @@ func (s *Server) CompletionResolve(_ context.Context, item *protocol.CompletionI
 		if !ok {
 			return item, nil
 		}
-		journal, _ := parser.Parse(doc)
+		journal, _ := s.cachedJournal(data.DocURI, doc)
 		allTransactions = journal.Transactions
 	}
 

--- a/internal/server/definition.go
+++ b/internal/server/definition.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/include"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 type DefinitionContext int
@@ -33,7 +32,7 @@ func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionPara
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 
 	target := findDefinitionTarget(journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {

--- a/internal/server/diagnostics_size_test.go
+++ b/internal/server/diagnostics_size_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/include"
+)
+
+func TestPublishDiagnostics_FileTooLargeSkipsParse(t *testing.T) {
+	ts := newTestServer()
+	ts.loader.SetLimits(include.Limits{
+		MaxFileSizeBytes: 50,
+		MaxIncludeDepth:  50,
+	})
+
+	// Over the 50-byte limit AND contains an unterminated comment block, which
+	// would yield a parse-error diagnostic if the content were parsed.
+	content := "comment\nThis comment block is never terminated and exceeds the limit.\n"
+	uri := protocol.DocumentURI("file:///too-large.journal")
+
+	diags, err := ts.openAndWait(uri, content)
+	require.NoError(t, err)
+
+	require.Len(t, diags, 1, "expected only the file-too-large diagnostic, got: %+v", diags)
+	d := diags[0]
+	assert.Contains(t, d.Message, "file too large")
+	assert.NotContains(t, d.Message, "unterminated")
+	assert.Equal(t, protocol.DiagnosticSeverityError, d.Severity)
+	assert.Equal(t, "hledger-lsp", d.Source)
+}

--- a/internal/server/diagnostics_workspace_test.go
+++ b/internal/server/diagnostics_workspace_test.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func initWorkspaceTestServer(t *testing.T, tmpDir string) *testServer {
+	t.Helper()
+	ts := newTestServer()
+	_, err := ts.Initialize(context.Background(), &protocol.InitializeParams{
+		WorkspaceFolders: []protocol.WorkspaceFolder{
+			{URI: fmt.Sprintf("file://%s", tmpDir), Name: "test"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ts.workspace)
+	require.NoError(t, ts.Initialized(context.Background(), &protocol.InitializedParams{}))
+	return ts
+}
+
+func writeIncludeFixture(t *testing.T) (tmpDir, mainPath, childPath string) {
+	t.Helper()
+	tmpDir = t.TempDir()
+	mainContent := "include child.journal\ninclude missing.journal\n\n2024-01-01 * x\n    expenses:a  $1\n    assets:cash\n"
+	childContent := "2024-01-02 * y\n    expenses:b  $2\n    assets:cash\n"
+	mainPath = filepath.Join(tmpDir, "main.journal")
+	childPath = filepath.Join(tmpDir, "child.journal")
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainContent), 0o644))
+	require.NoError(t, os.WriteFile(childPath, []byte(childContent), 0o644))
+	return tmpDir, mainPath, childPath
+}
+
+// The root file takes the workspace fast path and surfaces its own tree's
+// include errors (here: the missing.journal include).
+func TestPublishDiagnostics_RootGetsTreeLoadErrors(t *testing.T) {
+	tmpDir, mainPath, _ := writeIncludeFixture(t)
+	ts := initWorkspaceTestServer(t, tmpDir)
+
+	mainContent, err := os.ReadFile(mainPath)
+	require.NoError(t, err)
+	mainURI := protocol.DocumentURI(fmt.Sprintf("file://%s", mainPath))
+
+	diags, err := ts.openAndWait(mainURI, string(mainContent))
+	require.NoError(t, err)
+
+	foundMissing := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "cannot read included file") || strings.Contains(d.Message, "missing.journal") {
+			foundMissing = true
+			break
+		}
+	}
+	assert.True(t, foundMissing, "root should surface its tree's missing-include error, got: %+v", diags)
+}
+
+func TestPublishDiagnostics_DidOpenUsesBufferForRootLoadErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainPath := filepath.Join(tmpDir, "main.journal")
+	diskContent := "2024-01-01 * x\n    expenses:a  $1\n    assets:cash\n"
+	require.NoError(t, os.WriteFile(mainPath, []byte(diskContent), 0o644))
+
+	ts := initWorkspaceTestServer(t, tmpDir)
+	mainURI := protocol.DocumentURI(fmt.Sprintf("file://%s", mainPath))
+	bufferContent := "include missing.journal\n\n" + diskContent
+
+	diags, err := ts.openAndWait(mainURI, bufferContent)
+	require.NoError(t, err)
+
+	foundMissing := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "missing.journal") {
+			foundMissing = true
+			break
+		}
+	}
+	assert.True(t, foundMissing, "root should use the DidOpen buffer for include errors, got: %+v", diags)
+}
+
+func TestPublishDiagnostics_RootFallsBackAfterIncludedFileDidOpen(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainPath := filepath.Join(tmpDir, "main.journal")
+	childPath := filepath.Join(tmpDir, "child.journal")
+	diskContent := "include child.journal\n\n2024-01-01 * x\n    expenses:a  $1\n    assets:cash\n"
+	childContent := "2024-01-02 * y\n    expenses:b  $2\n    assets:cash\n"
+	require.NoError(t, os.WriteFile(mainPath, []byte(diskContent), 0o644))
+	require.NoError(t, os.WriteFile(childPath, []byte(childContent), 0o644))
+
+	ts := initWorkspaceTestServer(t, tmpDir)
+	ts.diagDebounce = time.Hour
+	mainURI := protocol.DocumentURI(fmt.Sprintf("file://%s", mainPath))
+	childURI := protocol.DocumentURI(fmt.Sprintf("file://%s", childPath))
+	bufferContent := "include missing.journal\n" + diskContent
+
+	require.NoError(t, ts.openDocument(mainURI, bufferContent))
+	defer ts.cancelDiagnostics(mainURI)
+	require.NoError(t, ts.openDocument(childURI, childContent))
+	defer ts.cancelDiagnostics(childURI)
+	ts.publishDiagnostics(context.Background(), mainURI, bufferContent, 0)
+
+	diagnostics := ts.client.getLastDiagnostics()
+	require.NotNil(t, diagnostics)
+	assert.Equal(t, mainURI, diagnostics.URI)
+
+	foundMissing := false
+	for _, diagnostic := range diagnostics.Diagnostics {
+		if strings.Contains(diagnostic.Message, "missing.journal") {
+			foundMissing = true
+			break
+		}
+	}
+	assert.True(t, foundMissing, "root should use the current buffer after an included file opens, got: %+v", diagnostics.Diagnostics)
+}
+
+// child.journal is included by main.journal, so it is NOT a root. It must not
+// inherit main's tree errors (the missing.journal include): the root-only guard
+// sends it through the LoadFromContent fallback, which scopes errors to child's
+// own subtree.
+func TestPublishDiagnostics_NonRootDoesNotInheritTreeErrors(t *testing.T) {
+	tmpDir, _, childPath := writeIncludeFixture(t)
+	ts := initWorkspaceTestServer(t, tmpDir)
+
+	childContent, err := os.ReadFile(childPath)
+	require.NoError(t, err)
+	childURI := protocol.DocumentURI(fmt.Sprintf("file://%s", childPath))
+
+	diags, err := ts.openAndWait(childURI, string(childContent))
+	require.NoError(t, err)
+
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "missing.journal",
+			"non-root file must not inherit sibling include errors, got: %+v", diags)
+		assert.NotContains(t, d.Message, "cannot read included file",
+			"non-root file must not inherit sibling include errors, got: %+v", diags)
+	}
+}

--- a/internal/server/folding.go
+++ b/internal/server/folding.go
@@ -6,8 +6,8 @@ import (
 
 	"go.lsp.dev/protocol"
 
+	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/filetype"
-	"github.com/juev/hledger-lsp/internal/parser"
 	"github.com/juev/hledger-lsp/internal/rules"
 )
 
@@ -25,9 +25,11 @@ func (s *Server) FoldingRanges(ctx context.Context, params *protocol.FoldingRang
 		return rulesFoldingRanges(doc), nil
 	}
 
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
+
 	var ranges []protocol.FoldingRange
 
-	ranges = append(ranges, findTransactionFolds(doc)...)
+	ranges = append(ranges, findTransactionFolds(journal)...)
 	ranges = append(ranges, findDirectiveFolds(doc)...)
 	ranges = append(ranges, findCommentBlockFolds(doc)...)
 	ranges = append(ranges, findCommentDirectiveFolds(doc)...)
@@ -53,8 +55,10 @@ func rulesFoldingRanges(doc string) []protocol.FoldingRange {
 	return result
 }
 
-func findTransactionFolds(content string) []protocol.FoldingRange {
-	journal, _ := parser.Parse(content)
+func findTransactionFolds(journal *ast.Journal) []protocol.FoldingRange {
+	if journal == nil {
+		return nil
+	}
 	var ranges []protocol.FoldingRange
 
 	for i := range journal.Transactions {

--- a/internal/server/highlight.go
+++ b/internal/server/highlight.go
@@ -6,7 +6,6 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/ast"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func (s *Server) DocumentHighlight(_ context.Context, params *protocol.DocumentHighlightParams) ([]protocol.DocumentHighlight, error) {
@@ -15,7 +14,7 @@ func (s *Server) DocumentHighlight(_ context.Context, params *protocol.DocumentH
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 
 	target := findDefinitionTarget(journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juev/hledger-lsp/internal/formatter"
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/lsputil"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 type HoverContext int
@@ -50,7 +49,7 @@ func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 
 	element := findElementAtPosition(journal, params.Position)
 	if element == nil || element.context == HoverUnknown {
@@ -76,7 +75,7 @@ func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 		}
 	} else {
 		allTransactions = journal.Transactions
-		balances = analyzer.CalculateAccountBalances(journal)
+		balances = s.cachedBalances(params.TextDocument.URI, doc)
 		commodityFormats = formatter.ExtractCommodityFormats(journal.Directives)
 		defSymbol = defaultCommoditySymbol(journal.Directives)
 	}

--- a/internal/server/hover_cache_test.go
+++ b/internal/server/hover_cache_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func TestHover_UsesCachedBalances(t *testing.T) {
+	srv := NewServer()
+	uri := protocol.DocumentURI("file:///test.journal")
+	content := "2024-01-15 grocery\n    expenses:food  $50\n    assets:cash  $-50\n"
+	srv.documents.Store(uri, content)
+
+	// Pre-warm the balances cache (non-workspace document → hover takes the
+	// non-resolved branch that reads cachedBalances).
+	warm := srv.cachedBalances(uri, content)
+	require.NotNil(t, warm)
+
+	hoverAt := func() string {
+		res, err := srv.Hover(context.Background(), &protocol.HoverParams{
+			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+				Position:     protocol.Position{Line: 1, Character: 10},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		return res.Contents.Value
+	}
+
+	first := hoverAt()
+	assert.Contains(t, first, "expenses:food")
+	assert.Contains(t, first, "50")
+
+	// Repeated hover is stable, and the balances map is a single cached instance
+	// (computed once via sync.Once), not recomputed per request.
+	second := hoverAt()
+	assert.Equal(t, first, second)
+
+	after := srv.cachedBalances(uri, content)
+	assert.Equal(t, reflect.ValueOf(warm).Pointer(), reflect.ValueOf(after).Pointer(),
+		"balances must be computed once and reused")
+}

--- a/internal/server/inline_completion.go
+++ b/internal/server/inline_completion.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/analyzer"
 	"github.com/juev/hledger-lsp/internal/formatter"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 type InlineCompletionTriggerKind int
@@ -95,7 +94,7 @@ func (s *Server) InlineCompletion(_ context.Context, params json.RawMessage) (*I
 	// here is independent of the payee-template path (which is cached and
 	// may not reflect the latest content); for inline completion latency,
 	// this is the same Parse cost as the cache-miss path of getPayeeTemplates.
-	journal, _ := parser.Parse(content)
+	journal, _ := s.cachedJournal(p.TextDocument.URI, content)
 	commodityFormats := formatter.ExtractCommodityFormats(journal.Directives)
 	alignment := formatter.ComputeAlignment(journal, commodityFormats, formatterOptionsFrom(settings.Formatting))
 
@@ -123,7 +122,7 @@ func (s *Server) getPayeeTemplates(uri protocol.DocumentURI, content string) map
 	if resolved := s.getWorkspaceResolved(uri); resolved != nil {
 		result = s.analyzer.AnalyzeResolved(resolved)
 	} else {
-		journal, _ := parser.Parse(content)
+		journal, _ := s.cachedJournal(uri, content)
 		result = s.analyzer.Analyze(journal)
 	}
 

--- a/internal/server/links.go
+++ b/internal/server/links.go
@@ -7,7 +7,6 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/filetype"
-	"github.com/juev/hledger-lsp/internal/parser"
 	"github.com/juev/hledger-lsp/internal/rules"
 )
 
@@ -28,7 +27,7 @@ func (s *Server) DocumentLink(ctx context.Context, params *protocol.DocumentLink
 		return rulesDocumentLinks(doc, currentDir), nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	if journal == nil || len(journal.Includes) == 0 {
 		return []protocol.DocumentLink{}, nil
 	}

--- a/internal/server/on_type_formatting.go
+++ b/internal/server/on_type_formatting.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/formatter"
 	"github.com/juev/hledger-lsp/internal/lsputil"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 type lineKind int
@@ -142,7 +141,7 @@ func (s *Server) formatPreviousPostingLine(doc string, uri protocol.DocumentURI,
 		return nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(uri, doc)
 	commodityFormats := s.commodityFormatsForDocument(uri)
 
 	settings := s.getSettings()
@@ -212,7 +211,7 @@ func (s *Server) getAlignmentColumn(doc string, uri protocol.DocumentURI) int {
 		}
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(uri, doc)
 	if len(journal.Transactions) == 0 {
 		return 0
 	}

--- a/internal/server/parse_cache.go
+++ b/internal/server/parse_cache.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"sync"
+
+	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/analyzer"
+	"github.com/juev/hledger-lsp/internal/ast"
+	"github.com/juev/hledger-lsp/internal/parser"
+)
+
+// cachedDoc holds the content-derived parse results for one document version.
+// It is immutable once published into Server.parseCache: fields are never
+// mutated after Store, and balances is computed at most once via balancesOnce.
+// This makes it safe to share across handler goroutines and the debounced
+// diagnostics goroutine.
+type cachedDoc struct {
+	content      string
+	journal      *ast.Journal
+	parseErrs    []parser.ParseError
+	balancesOnce sync.Once
+	balances     analyzer.AccountBalances
+}
+
+// cachedParse returns the parse result for content, reparsing only when the
+// document's cached content differs. The cache is keyed by URI and validated by
+// content identity, so a caller always receives a journal parsed from exactly
+// the content it passed; invalidation is automatic on content change.
+func (s *Server) cachedParse(docURI protocol.DocumentURI, content string) *cachedDoc {
+	if v, ok := s.parseCache.Load(docURI); ok {
+		if doc, ok := v.(*cachedDoc); ok && doc.content == content {
+			return doc
+		}
+	}
+	journal, parseErrs := parser.Parse(content)
+	doc := &cachedDoc{content: content, journal: journal, parseErrs: parseErrs}
+	s.parseCache.Store(docURI, doc)
+	return doc
+}
+
+// cachedJournal returns the cached parsed journal and parse errors for content.
+func (s *Server) cachedJournal(docURI protocol.DocumentURI, content string) (*ast.Journal, []parser.ParseError) {
+	doc := s.cachedParse(docURI, content)
+	return doc.journal, doc.parseErrs
+}
+
+// cachedBalances returns the account balances for content, computing them at
+// most once per document version.
+func (s *Server) cachedBalances(docURI protocol.DocumentURI, content string) analyzer.AccountBalances {
+	doc := s.cachedParse(docURI, content)
+	doc.balancesOnce.Do(func() {
+		doc.balances = analyzer.CalculateAccountBalances(doc.journal)
+	})
+	return doc.balances
+}
+
+// invalidateParseCache drops the cached parse for a document (called on DidClose).
+func (s *Server) invalidateParseCache(docURI protocol.DocumentURI) {
+	s.parseCache.Delete(docURI)
+}

--- a/internal/server/parse_cache_test.go
+++ b/internal/server/parse_cache_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+const sampleJournal = "2024-01-15 * store\n    expenses:food  $50\n    assets:cash  $-50\n"
+
+func TestCachedParse_ReusesJournalForSameContent(t *testing.T) {
+	srv := NewServer()
+	uri := protocol.DocumentURI("file:///a.journal")
+
+	first := srv.cachedParse(uri, sampleJournal)
+	second := srv.cachedParse(uri, sampleJournal)
+
+	require.NotNil(t, first.journal)
+	assert.Same(t, first.journal, second.journal, "same content must reuse the parsed journal")
+	assert.Equal(t, first.parseErrs, second.parseErrs)
+}
+
+func TestCachedParse_RebuildsOnContentChange(t *testing.T) {
+	srv := NewServer()
+	uri := protocol.DocumentURI("file:///a.journal")
+
+	first := srv.cachedParse(uri, sampleJournal)
+	changed := srv.cachedParse(uri, "2024-01-16 * other\n    expenses:y  $2\n    assets:cash  $-2\n")
+
+	assert.NotSame(t, first.journal, changed.journal, "changed content must reparse")
+}
+
+func TestCachedParse_RebuildsAfterInvalidate(t *testing.T) {
+	srv := NewServer()
+	uri := protocol.DocumentURI("file:///a.journal")
+
+	first := srv.cachedParse(uri, sampleJournal)
+	srv.invalidateParseCache(uri)
+	second := srv.cachedParse(uri, sampleJournal)
+
+	assert.NotSame(t, first.journal, second.journal, "invalidation must force a reparse")
+}
+
+func TestCachedParse_ConcurrentSafe(t *testing.T) {
+	srv := NewServer()
+	uri := protocol.DocumentURI("file:///a.journal")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			doc := srv.cachedParse(uri, sampleJournal)
+			assert.NotNil(t, doc.journal)
+			_ = srv.cachedBalances(uri, sampleJournal)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestCachedBalances_ComputedOnceAndCorrect(t *testing.T) {
+	srv := NewServer()
+	uri := protocol.DocumentURI("file:///a.journal")
+
+	balances := srv.cachedBalances(uri, sampleJournal)
+	require.NotNil(t, balances)
+	assert.True(t, balances["expenses:food"]["$"].Equal(decimal.NewFromInt(50)),
+		"expenses:food balance = 50, got %v", balances["expenses:food"]["$"])
+	assert.True(t, balances["assets:cash"]["$"].Equal(decimal.NewFromInt(-50)),
+		"assets:cash balance = -50, got %v", balances["assets:cash"]["$"])
+
+	// Same content returns the identical cached map (computed once via sync.Once).
+	again := srv.cachedBalances(uri, sampleJournal)
+	assert.Equal(t, balances, again)
+}

--- a/internal/server/payee_history.go
+++ b/internal/server/payee_history.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 
 	"go.lsp.dev/protocol"
-
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 type PayeeAccountHistoryParams struct {
@@ -40,7 +38,7 @@ func (s *Server) PayeeAccountHistory(_ context.Context, params json.RawMessage) 
 		}, nil
 	}
 
-	journal, errs := parser.Parse(content)
+	journal, errs := s.cachedJournal(p.TextDocument.URI, content)
 	if len(errs) > 0 || journal == nil {
 		return &PayeeAccountHistoryResult{
 			PayeeAccounts: make(map[string][]string),

--- a/internal/server/range_formatting.go
+++ b/internal/server/range_formatting.go
@@ -6,7 +6,6 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/formatter"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func (s *Server) RangeFormat(ctx context.Context, params *protocol.DocumentRangeFormattingParams) ([]protocol.TextEdit, error) {
@@ -15,7 +14,7 @@ func (s *Server) RangeFormat(ctx context.Context, params *protocol.DocumentRange
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	commodityFormats := s.commodityFormatsForDocument(params.TextDocument.URI)
 
 	settings := s.getSettings()

--- a/internal/server/references.go
+++ b/internal/server/references.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/include"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func (s *Server) References(ctx context.Context, params *protocol.ReferenceParams) ([]protocol.Location, error) {
@@ -17,7 +16,7 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 
 	target := findDefinitionTarget(journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"go.lsp.dev/protocol"
-
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (*protocol.Range, error) {
@@ -16,7 +14,7 @@ func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	target := findDefinitionTarget(journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {
 		return nil, nil
@@ -35,7 +33,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	target := findDefinitionTarget(journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {
 		return nil, nil

--- a/internal/server/rope_diverge_test.go
+++ b/internal/server/rope_diverge_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+
+	"github.com/juev/hledger-lsp/internal/document"
+)
+
+// TestDidChange_RebuildsDivergedRope reproduces the corruption where the
+// persisted rope diverges from the authoritative document content (as can happen
+// under concurrent DidChange interleaving) and an edit then lands in the wrong
+// place. applyChange must detect the divergence and rebuild the rope from the
+// authoritative content before applying the edit.
+func TestDidChange_RebuildsDivergedRope(t *testing.T) {
+	ts := newTestServer()
+	uri := protocol.DocumentURI("file:///diverge.journal")
+	full := "2024-01-01 one\n    expenses:a  $1\n    assets:cash\n\n2024-01-02 two\n    expenses:b  $2\n    assets:cash\n"
+	require.NoError(t, ts.openDocument(uri, full))
+
+	// Simulate a diverged rope: it reflects a shorter content than the
+	// authoritative document.
+	ts.docTexts.Store(uri, document.NewText("2024-01-01 one\n    expenses:a  $1\n    assets:cash\n"))
+
+	// Incremental insert at line 4 (the second transaction) of the FULL document.
+	require.NoError(t, ts.changeDocument(uri, []protocol.TextDocumentContentChangeEvent{{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 4, Character: 0},
+			End:   protocol.Position{Line: 4, Character: 0},
+		},
+		Text: "    expenses:inserted  $9\n",
+	}}))
+
+	got, ok := ts.GetDocument(uri)
+	require.True(t, ok)
+
+	// The second transaction must survive, and the insert must land at line 4 —
+	// not be clamped into the first transaction by the diverged shorter rope.
+	assert.Contains(t, got, "2024-01-02 two", "second transaction must not be lost")
+	assert.Contains(t, got, "2024-01-01 one\n    expenses:a  $1\n    assets:cash", "first transaction must stay intact")
+	assert.Contains(t, got, "    expenses:inserted  $9\n2024-01-02 two", "insert must land before the second transaction")
+}

--- a/internal/server/rope_wiring_test.go
+++ b/internal/server/rope_wiring_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+// TestDidChange_RopeIncrementalAndFullChange verifies the rope-backed applyChange
+// wiring: incremental edits accumulate on the persisted rope (including multi-line
+// and non-ASCII inserts), and a full-document change resets the rope so the next
+// incremental edit starts from the new content.
+func TestDidChange_RopeIncrementalAndFullChange(t *testing.T) {
+	ts := newTestServer()
+	uri := protocol.DocumentURI("file:///rope.journal")
+	base := "2024-01-01 * store\n    expenses:food  $50\n    assets:cash\n"
+	require.NoError(t, ts.openDocument(uri, base))
+
+	pos := func(line, char uint32) protocol.Position {
+		return protocol.Position{Line: line, Character: char}
+	}
+	apply := func(r protocol.Range, text string) string {
+		require.NoError(t, ts.changeDocument(uri, []protocol.TextDocumentContentChangeEvent{{Range: r, Text: text}}))
+		got, ok := ts.GetDocument(uri)
+		require.True(t, ok)
+		return got
+	}
+
+	// Incremental single-char insert (non-full range).
+	got := apply(protocol.Range{Start: pos(0, 5), End: pos(0, 5)}, "X")
+	assert.Equal(t, "2024-X01-01 * store\n    expenses:food  $50\n    assets:cash\n", got)
+
+	// Incremental multi-line + Cyrillic insert; the rope persists across edits.
+	got = apply(protocol.Range{Start: pos(1, 4), End: pos(1, 4)}, "расходы:еда  $1\n    ")
+	assert.Equal(t, "2024-X01-01 * store\n    расходы:еда  $1\n    expenses:food  $50\n    assets:cash\n", got)
+
+	// Full-document change replaces the content and resets the rope.
+	got = apply(protocol.Range{}, "2025-05-05 * fresh\n    assets:bank  $1\n    income:x\n")
+	assert.Equal(t, "2025-05-05 * fresh\n    assets:bank  $1\n    income:x\n", got)
+
+	// An incremental edit after a full change builds from the new content.
+	got = apply(protocol.Range{Start: pos(0, 4), End: pos(0, 4)}, "-")
+	assert.Equal(t, "2025--05-05 * fresh\n    assets:bank  $1\n    income:x\n", got)
+}

--- a/internal/server/selection_range.go
+++ b/internal/server/selection_range.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/lsputil"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func (s *Server) SelectionRange(_ context.Context, params *protocol.SelectionRangeParams) ([]protocol.SelectionRange, error) {
@@ -17,7 +16,7 @@ func (s *Server) SelectionRange(_ context.Context, params *protocol.SelectionRan
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	lines := strings.Split(doc, "\n")
 	docRange := documentRange(lines)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,11 +14,11 @@ import (
 	"github.com/juev/hledger-lsp/internal/analyzer"
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/cli"
+	"github.com/juev/hledger-lsp/internal/document"
 	"github.com/juev/hledger-lsp/internal/filetype"
 	"github.com/juev/hledger-lsp/internal/formatter"
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/lsputil"
-	"github.com/juev/hledger-lsp/internal/parser"
 	"github.com/juev/hledger-lsp/internal/rules"
 	"github.com/juev/hledger-lsp/internal/workspace"
 )
@@ -52,6 +52,9 @@ type Server struct {
 	payeeTemplatesCache   sync.Map // map[protocol.DocumentURI]map[string][]analyzer.PostingTemplate
 	alignmentCache        sync.Map // map[protocol.DocumentURI]int
 	tokenCache            *semanticTokensCache
+	parseCache            sync.Map // map[protocol.DocumentURI]*cachedDoc
+	docTexts              sync.Map // map[protocol.DocumentURI]*document.Text
+	docTextMu             sync.Mutex
 
 	diagDebounce time.Duration
 	diagMu       sync.Mutex
@@ -264,6 +267,14 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 	content := normalizeLineEndings(params.TextDocument.Text)
 	s.documents.Store(params.TextDocument.URI, content)
 	s.alignmentCache.Delete(params.TextDocument.URI)
+	s.invalidateDocText(params.TextDocument.URI)
+	if s.workspace != nil && s.loader.FileSizeError(content) == nil {
+		if path := uriToPath(params.TextDocument.URI); filetype.IsJournalPath(path) {
+			journal, _ := s.cachedJournal(params.TextDocument.URI, content)
+			s.workspace.UpdateFileWithJournal(path, content, journal)
+			s.loader.InvalidateFile(path)
+		}
+	}
 	s.scheduleDiagnostics(params.TextDocument.URI, content, uint32(params.TextDocument.Version))
 	return nil
 }
@@ -277,15 +288,19 @@ func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDo
 		for _, change := range params.ContentChanges {
 			if isFullChange(change.Range) {
 				content = normalizeLineEndings(change.Text)
+				s.invalidateDocText(params.TextDocument.URI)
 			} else {
-				content = applyChange(content, change.Range, normalizeLineEndings(change.Text))
+				content = s.applyChange(params.TextDocument.URI, content, change.Range, normalizeLineEndings(change.Text))
 			}
 		}
 		s.documents.Store(params.TextDocument.URI, content)
 		s.alignmentCache.Delete(params.TextDocument.URI)
 		if s.workspace != nil {
 			if path := uriToPath(params.TextDocument.URI); path != "" {
-				s.workspace.UpdateFile(path, content)
+				// Parse once and reuse the cached journal for workspace indexing
+				// (analyze and handlers reuse the same cache entry).
+				journal, _ := s.cachedJournal(params.TextDocument.URI, content)
+				s.workspace.UpdateFileWithJournal(path, content, journal)
 				s.loader.InvalidateFile(path)
 			}
 		}
@@ -323,6 +338,16 @@ func (s *Server) DidClose(ctx context.Context, params *protocol.DidCloseTextDocu
 	s.documents.Delete(params.TextDocument.URI)
 	s.alignmentCache.Delete(params.TextDocument.URI)
 	s.tokenCache.delete(params.TextDocument.URI)
+	s.invalidateParseCache(params.TextDocument.URI)
+	s.invalidateDocText(params.TextDocument.URI)
+	if s.workspace != nil {
+		if path := uriToPath(params.TextDocument.URI); filetype.IsJournalPath(path) {
+			if data, err := os.ReadFile(path); err == nil {
+				s.workspace.UpdateFile(path, normalizeLineEndings(string(data)))
+				s.loader.InvalidateFile(path)
+			}
+		}
+	}
 	return nil
 }
 
@@ -427,10 +452,41 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.Documen
 	if path == "" {
 		return
 	}
-	resolved, loadErrors := s.loader.LoadFromContent(path, content)
-	s.resolved.Store(docURI, resolved)
 
-	diagnostics := s.analyze(path, content)
+	// Guard the analyze path: a file over the size limit is not parsed. Publish a
+	// single diagnostic instead of running the lexer/parser on every keystroke.
+	if sizeErr := s.loader.FileSizeError(content); sizeErr != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		_ = s.client.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
+			URI:     docURI,
+			Version: version,
+			Diagnostics: []protocol.Diagnostic{
+				{
+					Severity: protocol.DiagnosticSeverityError,
+					Source:   "hledger-lsp",
+					Message:  sizeErr.Message,
+				},
+			},
+		})
+		return
+	}
+
+	// Prefer the workspace's already-resolved journal only when it was built
+	// from this root buffer. Otherwise LoadFromContent keeps diagnostics in sync
+	// with the editor after an included file invalidates the tree snapshot.
+	var resolved *include.ResolvedJournal
+	var loadErrors []include.LoadError
+	if s.workspace != nil {
+		resolved, loadErrors = s.workspace.ResolvedForRootContent(path, content)
+	}
+	if resolved == nil {
+		resolved, loadErrors = s.loader.LoadFromContent(path, content)
+		s.resolved.Store(docURI, resolved)
+	}
+
+	diagnostics := s.analyze(docURI, path, content)
 
 	if ctx.Err() != nil {
 		return
@@ -459,8 +515,8 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI protocol.Documen
 	})
 }
 
-func (s *Server) analyze(path, content string) []protocol.Diagnostic {
-	journal, parseErrs := parser.Parse(content)
+func (s *Server) analyze(docURI protocol.DocumentURI, path, content string) []protocol.Diagnostic {
+	journal, parseErrs := s.cachedJournal(docURI, content)
 
 	diagnostics := make([]protocol.Diagnostic, 0, len(parseErrs))
 	for _, err := range parseErrs {
@@ -725,7 +781,7 @@ func (s *Server) Format(ctx context.Context, params *protocol.DocumentFormatting
 		return nil, nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	commodityFormats := s.commodityFormatsForDocument(params.TextDocument.URI)
 
 	settings := s.getSettings()
@@ -767,6 +823,42 @@ func formatterOptionsFrom(f formattingSettings) formatter.Options {
 func applyChange(content string, r protocol.Range, text string) string {
 	mapper := lsputil.NewPositionMapper(content)
 	return mapper.ApplyChange(r, text)
+}
+
+// applyChange applies an incremental LSP edit to the document's cached rope and
+// returns the updated content. The rope is persisted per URI so consecutive
+// edits do not re-split the whole document: the edit itself is O(log n) in the
+// line count, and the returned string is materialized once (O(n)) for the
+// string-based consumers downstream. content is the authoritative pre-edit
+// document text.
+func (s *Server) applyChange(docURI protocol.DocumentURI, content string, r protocol.Range, text string) string {
+	s.docTextMu.Lock()
+	defer s.docTextMu.Unlock()
+	var dt *document.Text
+	if v, ok := s.docTexts.Load(docURI); ok {
+		dt = v.(*document.Text)
+	}
+	// The persisted rope is only trustworthy while it matches the authoritative
+	// content. If it diverged (e.g. concurrent DidChange interleaving), rebuild
+	// from content so the edit lands at the correct position instead of
+	// corrupting the buffer. In the common in-sync case dt.String() is the cached
+	// string identical to content, so this check is cheap.
+	if dt == nil || dt.String() != content {
+		dt = document.NewText(content)
+	}
+	dt.ApplyChange(r, text)
+	updated := dt.String()
+	s.docTexts.Store(docURI, dt)
+	return updated
+}
+
+// invalidateDocText drops the cached rope for a document so the next incremental
+// edit rebuilds it from the current content (called on DidOpen, full changes and
+// DidClose).
+func (s *Server) invalidateDocText(docURI protocol.DocumentURI) {
+	s.docTextMu.Lock()
+	s.docTexts.Delete(docURI)
+	s.docTextMu.Unlock()
 }
 
 func splitLines(s string) []string {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -405,6 +406,36 @@ func TestServer_DidClose(t *testing.T) {
 
 	_, ok = srv.GetDocument(uri)
 	assert.False(t, ok)
+}
+
+func TestServer_DidClose_RestoresWorkspaceIndexFromDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	journalPath := filepath.Join(tmpDir, "main.journal")
+	diskContent := "account assets:disk\n"
+	unsavedContent := "account assets:discarded\n"
+	require.NoError(t, os.WriteFile(journalPath, []byte(diskContent), 0644))
+
+	srv := NewServer()
+	_, err := srv.Initialize(context.Background(), &protocol.InitializeParams{RootURI: uri.File(tmpDir)})
+	require.NoError(t, err)
+	require.NoError(t, srv.workspace.Initialize())
+
+	journalURI := uri.File(journalPath)
+	require.NoError(t, srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: journalURI, Text: unsavedContent},
+	}))
+
+	accounts := srv.workspace.GetDeclaredAccountsForFile(journalPath)
+	assert.Contains(t, accounts, "assets:discarded")
+	assert.NotContains(t, accounts, "assets:disk")
+
+	require.NoError(t, srv.DidClose(context.Background(), &protocol.DidCloseTextDocumentParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: journalURI},
+	}))
+
+	accounts = srv.workspace.GetDeclaredAccountsForFile(journalPath)
+	assert.Contains(t, accounts, "assets:disk")
+	assert.NotContains(t, accounts, "assets:discarded")
 }
 
 func TestServer_DidSave(t *testing.T) {

--- a/internal/server/symbol.go
+++ b/internal/server/symbol.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/filetype"
-	"github.com/juev/hledger-lsp/internal/parser"
 	"github.com/juev/hledger-lsp/internal/rules"
 )
 
@@ -26,7 +25,7 @@ func (s *Server) DocumentSymbol(
 		return rulesDocumentSymbols(doc), nil
 	}
 
-	journal, _ := parser.Parse(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	if journal == nil {
 		return []any{}, nil
 	}

--- a/internal/server/workspace_symbol.go
+++ b/internal/server/workspace_symbol.go
@@ -7,7 +7,6 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/ast"
-	"github.com/juev/hledger-lsp/internal/parser"
 )
 
 func (s *Server) WorkspaceSymbol(ctx context.Context, params *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
@@ -63,7 +62,7 @@ func (s *Server) WorkspaceSymbol(ctx context.Context, params *protocol.Workspace
 			return true
 		}
 		content := value.(string)
-		journal, _ := parser.Parse(content)
+		journal, _ := s.cachedJournal(docURI, content)
 		if journal == nil {
 			return true
 		}

--- a/internal/workspace/update_journal_test.go
+++ b/internal/workspace/update_journal_test.go
@@ -1,0 +1,54 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/parser"
+)
+
+func TestWorkspace_UpdateFileWithJournal_MatchesUpdateFile(t *testing.T) {
+	t.Setenv("LEDGER_FILE", "")
+	t.Setenv("HLEDGER_JOURNAL", "")
+
+	tmpDir := t.TempDir()
+	content := "2024-01-01 store\n    expenses:food  $20\n    assets:cash\n"
+	mainPath := filepath.Join(tmpDir, "main.journal")
+	require.NoError(t, os.WriteFile(mainPath, []byte(content), 0o644))
+
+	edited := "2024-01-01 store\n    expenses:food  $20\n    assets:cash\n\n2024-01-02 extra\n    expenses:rent  $5\n    assets:bank\n"
+
+	// Reference path: UpdateFile parses internally.
+	wsRef := NewWorkspace(tmpDir, include.NewLoader())
+	require.NoError(t, wsRef.Initialize())
+	wsRef.UpdateFile(mainPath, edited)
+	refAccounts := wsRef.IndexSnapshot().Accounts.All
+
+	// UpdateFileWithJournal receives a pre-parsed journal and must build the
+	// identical index.
+	ws := NewWorkspace(tmpDir, include.NewLoader())
+	require.NoError(t, ws.Initialize())
+	journal, _ := parser.Parse(edited)
+	ws.UpdateFileWithJournal(mainPath, edited, journal)
+
+	snap := ws.IndexSnapshot()
+	assert.Equal(t, refAccounts, snap.Accounts.All)
+	assert.Contains(t, snap.Accounts.All, "expenses:rent")
+
+	// The owning root's resolved journal must reflect the edited transaction.
+	resolved := ws.GetResolvedForFile(mainPath)
+	require.NotNil(t, resolved)
+	found := false
+	for _, tx := range resolved.AllTransactions() {
+		if tx.Description == "extra" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "resolved journal must include the edited transaction")
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -28,12 +28,14 @@ func normalizeLineEndings(s string) string {
 // Each root file (file with no incoming include edges) gets its own tree
 // with an independent ResolvedJournal and caches.
 type IncludeTree struct {
-	RootPath          string
-	Resolved          *include.ResolvedJournal
-	LoadErrors        []include.LoadError
-	cachedFormats     map[string]formatter.CommodityFormat
-	cachedCommodities map[string]bool
-	cachedAccounts    map[string]bool
+	RootPath                   string
+	Resolved                   *include.ResolvedJournal
+	LoadErrors                 []include.LoadError
+	rootContentSnapshot        string
+	rootContentSnapshotIsValid bool
+	cachedFormats              map[string]formatter.CommodityFormat
+	cachedCommodities          map[string]bool
+	cachedAccounts             map[string]bool
 }
 
 func (t *IncludeTree) clearCaches() {
@@ -262,11 +264,17 @@ func (w *Workspace) GetResolvedForFile(path string) *include.ResolvedJournal {
 	return tree.Resolved
 }
 
-// RootForFile returns the root journal path for the tree containing the given file.
-func (w *Workspace) RootForFile(path string) string {
+// ResolvedForRootContent returns a root tree only when its resolved state was
+// built from content. The caller must pass CRLF-normalized content.
+func (w *Workspace) ResolvedForRootContent(path, content string) (*include.ResolvedJournal, []include.LoadError) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	return w.primaryRootLocked(path)
+
+	tree := w.trees[path]
+	if tree == nil || !tree.rootContentSnapshotIsValid || tree.rootContentSnapshot != content {
+		return nil, nil
+	}
+	return tree.Resolved, tree.LoadErrors
 }
 
 // primaryRootLocked returns the lexicographically smallest owning root for path.
@@ -351,6 +359,18 @@ func (w *Workspace) UpdateFile(path, content string) {
 	if path == "" || !filetype.IsJournalPath(path) {
 		return
 	}
+	journal, _ := parser.Parse(normalizeLineEndings(content))
+	w.UpdateFileWithJournal(path, content, journal)
+}
+
+// UpdateFileWithJournal updates the workspace index and owning trees for path
+// using a pre-parsed journal, avoiding a redundant parse on the hot path
+// (DidChange parses once and reuses the cached journal). The journal must be
+// parsed from CRLF-normalized content.
+func (w *Workspace) UpdateFileWithJournal(path, content string, journal *ast.Journal) {
+	if path == "" || !filetype.IsJournalPath(path) {
+		return
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -367,7 +387,7 @@ func (w *Workspace) UpdateFile(path, content string) {
 		oldIncludes = append([]string(nil), oldIndex.Includes...)
 	}
 
-	fileIndex, _, _ := BuildFileIndexFromContent(path, content)
+	fileIndex := BuildFileIndexFromJournal(path, journal)
 	w.index.SetFileIndex(path, fileIndex)
 	w.updateIncludeEdgesLocked(path, oldIncludes, fileIndex.Includes)
 
@@ -388,6 +408,10 @@ func (w *Workspace) UpdateFile(path, content string) {
 		resolved, errs := w.loader.LoadWithOptions(rootPath, opts)
 		tree.Resolved = resolved
 		tree.LoadErrors = errs
+		tree.rootContentSnapshotIsValid = rootPath == path
+		if tree.rootContentSnapshotIsValid {
+			tree.rootContentSnapshot = normalizeLineEndings(content)
+		}
 		tree.clearCaches()
 		w.syncOwnershipFromResolvedLocked(tree)
 	}


### PR DESCRIPTION
Closes #35.

## Summary

Optimizes the LSP request path by reusing parsed documents and applying incremental edits without rebuilding a full position mapper for every keystroke.

## Changes

- Add an immutable per-document parse cache and lazily cached account balances shared by diagnostics and request handlers.
- Add a UTF-16-aware rope buffer for incremental edits, with divergence detection against the authoritative document content.
- Skip parsing files that exceed the configured size limit.
- Keep workspace diagnostics and resolved journals synchronized with open buffers, and restore the workspace index from disk when a document closes.
- Add correctness, race, cache, workspace-diagnostics, and NFR coverage for the optimized paths.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `golangci-lint run ./...`
- `go test -tags=nfr ./internal/benchmark`
