### PR TITLE
fix(server): respect configured account hover formats

### DIFF
--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -251,7 +251,16 @@ func buildAccountHoverWithTransactions(accountName string, balances analyzer.Acc
 	if commodityBalances, ok := balances[accountName]; ok && len(commodityBalances) > 0 {
 		displayFormats := make(map[string]formatter.CommodityFormat, len(commodityFormats))
 		maps.Copy(displayFormats, commodityFormats)
-		enrichCommodityFormatsFromTransactions(displayFormats, transactions)
+		inferredFormats := inferredCommodityFormatsFromTransactions(transactions)
+		for sym, inferred := range inferredFormats {
+			if _, hasSpecific := displayFormats[sym]; hasSpecific {
+				continue
+			}
+			if _, hasDefault := displayFormats[""]; hasDefault {
+				continue
+			}
+			displayFormats[sym] = inferred
+		}
 
 		displayBalances := make(map[string]decimal.Decimal, len(commodityBalances))
 		maps.Copy(displayBalances, commodityBalances)
@@ -273,6 +282,9 @@ func buildAccountHoverWithTransactions(accountName string, balances analyzer.Acc
 
 		for _, c := range commodities {
 			bal := displayBalances[c]
+			if format, ok := configuredCommodityFormat(c, commodityFormats); ok && format.DecimalPlaces > 0 {
+				bal = bal.Round(int32(format.DecimalPlaces))
+			}
 			fmt.Fprintf(&sb, "- %s\n", formatter.FormatBalance(bal, c, displayFormats))
 		}
 		sb.WriteString("\n")
@@ -285,6 +297,18 @@ func buildAccountHoverWithTransactions(accountName string, balances analyzer.Acc
 }
 
 func enrichCommodityFormatsFromTransactions(formats map[string]formatter.CommodityFormat, transactions []ast.Transaction) {
+	if _, hasDefault := formats[""]; hasDefault {
+		return
+	}
+	for sym, inferred := range inferredCommodityFormatsFromTransactions(transactions) {
+		if _, configured := formats[sym]; !configured {
+			formats[sym] = inferred
+		}
+	}
+}
+
+func inferredCommodityFormatsFromTransactions(transactions []ast.Transaction) map[string]formatter.CommodityFormat {
+	formats := make(map[string]formatter.CommodityFormat)
 	for i := range transactions {
 		for j := range transactions[i].Postings {
 			amt := transactions[i].Postings[j].Amount
@@ -308,6 +332,15 @@ func enrichCommodityFormatsFromTransactions(formats map[string]formatter.Commodi
 			formats[sym] = existing
 		}
 	}
+	return formats
+}
+
+func configuredCommodityFormat(symbol string, configured map[string]formatter.CommodityFormat) (formatter.CommodityFormat, bool) {
+	if format, ok := configured[symbol]; ok {
+		return format, true
+	}
+	format, ok := configured[""]
+	return format, ok
 }
 
 // decimalPlaces returns the number of decimal places in an amount,

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -1118,3 +1118,78 @@ func TestEnrichCommodityFormatsFromTransactions_DecimalPlaces(t *testing.T) {
 	assert.True(t, usdFormat.HasDecimal, "HasDecimal should be true")
 	assert.Equal(t, 2, usdFormat.DecimalPlaces, "DecimalPlaces should be 2")
 }
+
+func TestHover_AccountBalanceSpecificCommodityFormatRoundsAggregate(t *testing.T) {
+	srv := NewServer()
+	content := `commodity 1.000,00 RUB
+
+2024-01-15 grocery
+    expenses:food  1000,123 RUB
+    assets:cash`
+
+	srv.documents.Store(uri.URI("file:///test.journal"), content)
+
+	result, err := srv.Hover(context.Background(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.journal"},
+			Position:     protocol.Position{Line: 3, Character: 10},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Contains(t, hoverContent(result), "1.000,12 RUB")
+	assert.NotContains(t, hoverContent(result), "1.000,123 RUB")
+}
+
+func TestHover_AccountBalanceDefaultFormatRoundsOtherCommodityAggregate(t *testing.T) {
+	srv := NewServer()
+	content := `D 1.000,00 RUB
+
+2024-01-15 grocery
+    expenses:food  1000.123 EUR
+    assets:cash`
+
+	srv.documents.Store(uri.URI("file:///test.journal"), content)
+
+	result, err := srv.Hover(context.Background(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.journal"},
+			Position:     protocol.Position{Line: 3, Character: 10},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Contains(t, hoverContent(result), "1.000,12 EUR")
+	assert.NotContains(t, hoverContent(result), "1.000.123 EUR")
+}
+
+func TestEnrichCommodityFormatsFromTransactionsDoesNotMutateConfiguredFormat(t *testing.T) {
+	configured := map[string]formatter.CommodityFormat{
+		"RUB": {
+			NumberFormat: formatter.NumberFormat{
+				DecimalMark:   ',',
+				ThousandsSep:  ".",
+				DecimalPlaces: 2,
+				HasDecimal:    true,
+			},
+			Position:     ast.CommodityRight,
+			SpaceBetween: true,
+		},
+	}
+	want := configured["RUB"]
+	transactions := []ast.Transaction{{
+		Postings: []ast.Posting{{
+			Amount: &ast.Amount{
+				Quantity:    decimal.RequireFromString("1000.123"),
+				RawQuantity: "1000.123",
+				Commodity:   ast.Commodity{Symbol: "RUB", Position: ast.CommodityRight},
+			},
+		}},
+	}}
+
+	enrichCommodityFormatsFromTransactions(configured, transactions)
+
+	assert.Equal(t, want, configured["RUB"])
+}


### PR DESCRIPTION
## Purpose

Account hover should render aggregate balances using the format effective at
the hovered posting. An explicit `commodity` format takes precedence, `D` acts
as the fallback, and transaction-derived formatting applies only when neither
is configured.

Closes #63

## Changes

- Preserve configured commodity formats when inferring formats from
  transactions.
- Round only the displayed aggregate balance to configured precision, leaving
  amount formatting and inlay hints unchanged.
- Add regression tests for commodity-specific formatting, the default `D`
  fallback, and configured-format preservation.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `golangci-lint run ./...`
- `git diff --check`

All commands completed with exit code 0; `golangci-lint` reported `0 issues`.

## Code pointers

- `internal/server/hover.go`: configured/default/inferred format selection and
  account-hover display rounding.
- `internal/server/hover_test.go`: regression coverage for issue #63.
