### PR TITLE
feat(semantic-tokens): add diagnostic modifiers

### DIFF
--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -98,8 +98,16 @@ With hledger-vscode, use the `:hledger` suffix to apply colors only to hledger f
   "editor.semanticTokenColorCustomizations": {
     "rules": {
       "account:hledger": "#4EC9B0",
+      "namespace.undeclared:hledger": {
+        "foreground": "#F14C4C",
+        "fontStyle": "underline"
+      },
       "date:hledger": "#B5CEA8",
       "amount:hledger": "#B5CEA8",
+      "number.unbalanced:hledger": {
+        "foreground": "#F14C4C",
+        "fontStyle": "underline"
+      },
       "commodity:hledger": "#569CD6",
       "payee:hledger": "#DCDCAA",
       "directive:hledger": "#C586C0",
@@ -122,8 +130,16 @@ Without a registered language ID, colors apply globally:
   "editor.semanticTokenColorCustomizations": {
     "rules": {
       "account": "#4EC9B0",
+      "namespace.undeclared": {
+        "foreground": "#F14C4C",
+        "fontStyle": "underline"
+      },
       "date": "#B5CEA8",
       "amount": "#B5CEA8",
+      "number.unbalanced": {
+        "foreground": "#F14C4C",
+        "fontStyle": "underline"
+      },
       "commodity": "#569CD6",
       "payee": "#DCDCAA",
       "directive": "#C586C0",

--- a/internal/server/semantic.go
+++ b/internal/server/semantic.go
@@ -43,6 +43,8 @@ const (
 	ModifierDefinition  = 1
 	ModifierAbstract    = 5
 	ModifierNegative    = 6 // custom: amounts with a leading minus sign
+	ModifierUndeclared  = 7 // custom: accounts with an UNDECLARED_ACCOUNT diagnostic
+	ModifierUnbalanced  = 8 // custom: amounts in an UNBALANCED transaction
 )
 
 type SemanticTokensFullOptions struct {
@@ -78,7 +80,9 @@ func GetSemanticTokensLegend() protocol.SemanticTokensLegend {
 			string(protocol.SemanticTokenModifiersStatic),      // 3
 			string(protocol.SemanticTokenModifiersDeprecated),  // 4
 			string(protocol.SemanticTokenModifiersAbstract),    // 5: virtual accounts
-			"negative", // 6: negative amounts
+			"negative",   // 6: negative amounts
+			"undeclared", // 7: accounts with an UNDECLARED_ACCOUNT diagnostic
+			"unbalanced", // 8: amounts in an UNBALANCED transaction
 		},
 	}
 }
@@ -165,7 +169,7 @@ func (s *Server) SemanticTokensFull(ctx context.Context, params *protocol.Semant
 		return &protocol.SemanticTokens{Data: []uint32{}}, nil
 	}
 
-	tokens := tokenizeDoc(params.TextDocument.URI, doc)
+	tokens := s.semanticTokensForDocument(params.TextDocument.URI, doc)
 	data := encodeTokens(tokens)
 	resultID := s.tokenCache.set(params.TextDocument.URI, tokens, data)
 
@@ -185,7 +189,7 @@ func (s *Server) SemanticTokensRange(ctx context.Context, params *protocol.Seman
 		return &protocol.SemanticTokens{Data: []uint32{}}, nil
 	}
 
-	allTokens := tokenizeDoc(params.TextDocument.URI, doc)
+	allTokens := s.semanticTokensForDocument(params.TextDocument.URI, doc)
 	filteredTokens := filterTokensByRange(allTokens, params.Range)
 	data := encodeTokens(filteredTokens)
 
@@ -200,6 +204,84 @@ func tokenizeDoc(uri uri.URI, doc string) []semanticToken {
 		return tokenizeRulesForSemantics(doc)
 	}
 	return tokenizeForSemantics(doc)
+}
+
+// semanticTokensForDocument adds diagnostic modifiers to journal tokens. Rules
+// files and documents that cannot enter the diagnostics path remain syntax-only.
+func (s *Server) semanticTokensForDocument(docURI uri.URI, doc string) []semanticToken {
+	tokens := tokenizeDoc(docURI, doc)
+	if filetype.IsRules(string(docURI)) {
+		return tokens
+	}
+
+	settings := s.getSettings()
+	if !settings.Features.Diagnostics || s.loader.FileSizeError(doc) != nil {
+		return tokens
+	}
+
+	path := uriToPath(docURI)
+	if path == "" {
+		return tokens
+	}
+
+	undeclaredByLine := make(map[uint32][]protocol.Range)
+	unbalancedByLine := make(map[uint32][]protocol.Range)
+	for _, diagnostic := range s.analyze(docURI, path, doc) {
+		code, ok := diagnostic.Code.(protocol.String)
+		if !ok {
+			continue
+		}
+		switch string(code) {
+		case "UNDECLARED_ACCOUNT":
+			indexDiagnosticRangeByLine(undeclaredByLine, diagnostic.Range)
+		case "UNBALANCED":
+			indexDiagnosticRangeByLine(unbalancedByLine, diagnostic.Range)
+		}
+	}
+
+	for index := range tokens {
+		switch tokens[index].tokenType {
+		case TokenTypeAccount:
+			for _, diagnosticRange := range undeclaredByLine[tokens[index].line] {
+				if semanticTokenOverlapsRange(tokens[index], diagnosticRange) {
+					tokens[index].modifiers |= 1 << ModifierUndeclared
+					break
+				}
+			}
+		case TokenTypeAmount:
+			for _, diagnosticRange := range unbalancedByLine[tokens[index].line] {
+				if semanticRangeContainsToken(diagnosticRange, tokens[index]) {
+					tokens[index].modifiers |= 1 << ModifierUnbalanced
+					break
+				}
+			}
+		}
+	}
+
+	return tokens
+}
+
+func indexDiagnosticRangeByLine(index map[uint32][]protocol.Range, diagnosticRange protocol.Range) {
+	for line := diagnosticRange.Start.Line; ; line++ {
+		index[line] = append(index[line], diagnosticRange)
+		if line == diagnosticRange.End.Line {
+			break
+		}
+	}
+}
+
+func semanticTokenOverlapsRange(token semanticToken, diagnosticRange protocol.Range) bool {
+	tokenRange := protocol.Range{
+		Start: protocol.Position{Line: token.line, Character: token.col},
+		End:   protocol.Position{Line: token.line, Character: token.col + token.length},
+	}
+	return positionBefore(tokenRange.Start, diagnosticRange.End) && positionBefore(diagnosticRange.Start, tokenRange.End)
+}
+
+func semanticRangeContainsToken(diagnosticRange protocol.Range, token semanticToken) bool {
+	start := protocol.Position{Line: token.line, Character: token.col}
+	end := protocol.Position{Line: token.line, Character: token.col + token.length}
+	return !positionBefore(start, diagnosticRange.Start) && !positionBefore(diagnosticRange.End, end)
 }
 
 // tokenizeRulesForSemantics converts rules semantic tokens to the server's token format.
@@ -240,7 +322,7 @@ func rulesTokenTypeToServer(t rules.SemTokenType) uint32 {
 func filterTokensByRange(tokens []semanticToken, r protocol.Range) []semanticToken {
 	var filtered []semanticToken
 	for _, tok := range tokens {
-		if tok.line >= r.Start.Line && tok.line <= r.End.Line {
+		if semanticTokenOverlapsRange(tok, r) {
 			filtered = append(filtered, tok)
 		}
 	}

--- a/internal/server/semantic_test.go
+++ b/internal/server/semantic_test.go
@@ -2,12 +2,17 @@ package server
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
+
+	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/workspace"
 )
 
 func TestSemanticTokens_Legend(t *testing.T) {
@@ -27,7 +32,9 @@ func TestSemanticTokens_Legend(t *testing.T) {
 	assert.Equal(t, string(protocol.SemanticTokenTypesRegexp), legend.TokenTypes[10])
 	assert.Equal(t, string(protocol.SemanticTokenTypesParameter), legend.TokenTypes[11])
 
-	assert.Contains(t, legend.TokenModifiers, string(protocol.SemanticTokenModifiersAbstract))
+	assert.Equal(t, "negative", legend.TokenModifiers[ModifierNegative])
+	assert.Equal(t, "undeclared", legend.TokenModifiers[ModifierUndeclared])
+	assert.Equal(t, "unbalanced", legend.TokenModifiers[ModifierUnbalanced])
 }
 
 func TestSemanticTokens_Encode(t *testing.T) {
@@ -293,6 +300,22 @@ func TestSemanticTokens_Range(t *testing.T) {
 
 	assert.Less(t, len(result.Data), len(fullResult.Data),
 		"range result should have fewer tokens than full result")
+}
+
+func TestSemanticTokens_RangeFiltersCharactersOnBoundaryLines(t *testing.T) {
+	tokens := []semanticToken{
+		{line: 2, col: 4, length: 5, tokenType: TokenTypeAccount},
+		{line: 2, col: 11, length: 2, tokenType: TokenTypeAmount},
+		{line: 2, col: 15, length: 3, tokenType: TokenTypeCommodity},
+	}
+
+	filtered := filterTokensByRange(tokens, protocol.Range{
+		Start: protocol.Position{Line: 2, Character: 10},
+		End:   protocol.Position{Line: 2, Character: 14},
+	})
+
+	require.Len(t, filtered, 1)
+	assert.Equal(t, uint32(TokenTypeAmount), filtered[0].tokenType)
 }
 
 func TestSemanticTokens_DeltaNotAdvertised(t *testing.T) {
@@ -1303,4 +1326,209 @@ func TestSemanticTokens_TaggedCommentMarkerIsComment(t *testing.T) {
 func TestSemanticTokens_Legend_NegativeModifier(t *testing.T) {
 	legend := GetSemanticTokensLegend()
 	assert.Contains(t, legend.TokenModifiers, string(protocol.SemanticTokenModifiers("negative")))
+}
+
+func TestSemanticTokens_DiagnosticModifiers_FullAndRange(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///diagnostics.journal")
+	content := `account assets:cash
+account expenses:food
+2024-01-01 unbalanced
+    custom:wallet  -10 USD
+    assets:cash  5 USD
+2024-01-02 balanced
+    expenses:food  10 USD
+    assets:cash  -10 USD
+2024-01-03 virtual
+    (custom:virtual)`
+	srv.documents.Store(docURI, content)
+
+	full, err := srv.SemanticTokensFull(context.Background(), &protocol.SemanticTokensParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+	})
+	require.NoError(t, err)
+	fullTokens := decodeSemanticTokens(full.Data)
+
+	undeclared := semanticTokenAt(fullTokens, 3, TokenTypeAccount)
+	require.NotNil(t, undeclared)
+	assert.NotZero(t, undeclared.modifiers&(1<<ModifierUndeclared))
+
+	for _, line := range []uint32{3, 4} {
+		for _, token := range semanticAmountTokensOnLine(fullTokens, line) {
+			assert.NotZero(t, token.modifiers&(1<<ModifierUnbalanced), "line %d", line)
+		}
+	}
+	negative := semanticTokenAt(fullTokens, 3, TokenTypeAmount)
+	require.NotNil(t, negative)
+	assert.NotZero(t, negative.modifiers&(1<<ModifierNegative))
+	for _, line := range []uint32{6, 7} {
+		for _, token := range semanticAmountTokensOnLine(fullTokens, line) {
+			assert.Zero(t, token.modifiers&(1<<ModifierUnbalanced), "line %d", line)
+		}
+	}
+	virtual := semanticTokenAt(fullTokens, 9, TokenTypeAccount)
+	require.NotNil(t, virtual)
+	assert.NotZero(t, virtual.modifiers&(1<<ModifierAbstract))
+	assert.NotZero(t, virtual.modifiers&(1<<ModifierUndeclared))
+
+	rangeResult, err := srv.SemanticTokensRange(context.Background(), &protocol.SemanticTokensRangeParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 3},
+			End:   protocol.Position{Line: 4, Character: 100},
+		},
+	})
+	require.NoError(t, err)
+	rangeAmounts := semanticAmountTokensOnLine(decodeSemanticTokens(rangeResult.Data), 3)
+	require.NotEmpty(t, rangeAmounts)
+	for _, token := range rangeAmounts {
+		assert.NotZero(t, token.modifiers&(1<<ModifierUnbalanced))
+	}
+}
+
+func TestSemanticTokens_DiagnosticModifiers_RespectSettingsAndTolerance(t *testing.T) {
+	docURI := uri.URI("file:///settings.journal")
+	content := "account assets:cash\n2024-01-01 test\n    custom:wallet  10 USD\n    assets:cash  -9.995 USD"
+
+	t.Run("diagnostics feature disabled", func(t *testing.T) {
+		srv := NewServer()
+		settings := srv.getSettings()
+		settings.Features.Diagnostics = false
+		srv.setSettings(settings)
+		srv.documents.Store(docURI, content)
+		assertNoDiagnosticModifiers(t, semanticTokensForDocument(t, srv, docURI))
+	})
+
+	t.Run("individual diagnostic settings disabled", func(t *testing.T) {
+		srv := NewServer()
+		settings := srv.getSettings()
+		settings.Diagnostics.UndeclaredAccounts = false
+		settings.Diagnostics.UnbalancedTransactions = false
+		srv.setSettings(settings)
+		srv.documents.Store(docURI, content)
+		assertNoDiagnosticModifiers(t, semanticTokensForDocument(t, srv, docURI))
+	})
+
+	t.Run("balance tolerance", func(t *testing.T) {
+		srv := NewServer()
+		settings := srv.getSettings()
+		settings.Diagnostics.BalanceTolerance = 0.01
+		srv.setSettings(settings)
+		srv.documents.Store(docURI, content)
+		for _, token := range semanticAmountTokensOnLine(semanticTokensForDocument(t, srv, docURI), 2) {
+			assert.Zero(t, token.modifiers&(1<<ModifierUnbalanced))
+		}
+	})
+}
+
+func TestSemanticTokens_DiagnosticModifiers_SkipOversizedFile(t *testing.T) {
+	srv := NewServer()
+	srv.loader.SetLimits(include.Limits{MaxFileSizeBytes: 10, MaxIncludeDepth: 50})
+	docURI := uri.URI("file:///oversized.journal")
+	content := "2024-01-01 test\n    custom:wallet  10 USD\n"
+	srv.documents.Store(docURI, content)
+
+	assertNoDiagnosticModifiers(t, semanticTokensForDocument(t, srv, docURI))
+	_, cached := srv.parseCache.Load(docURI)
+	assert.False(t, cached, "oversized semantic request must not invoke analysis")
+}
+
+func TestSemanticTokens_DiagnosticModifiers_RulesStaySyntaxOnly(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///import.rules")
+	srv.documents.Store(docURI, "fields date\n")
+
+	assertNoDiagnosticModifiers(t, semanticTokensForDocument(t, srv, docURI))
+	_, cached := srv.parseCache.Load(docURI)
+	assert.False(t, cached, "rules semantic request must not invoke journal analysis")
+}
+
+func TestSemanticTokens_DiagnosticModifiers_UseWorkspaceDeclarationsAndNormalizedText(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.journal")
+	childPath := filepath.Join(dir, "accounts.journal")
+	content := "include accounts.journal\r\n2024-01-01 \U0001f600 test\r\n    custom:wallet  10 USD\r\n    expenses:food  -9 USD\r\n"
+	require.NoError(t, os.WriteFile(mainPath, []byte(content), 0o600))
+	require.NoError(t, os.WriteFile(childPath, []byte("account expenses:food\n"), 0o600))
+
+	srv := NewServer()
+	srv.workspace = workspace.NewWorkspace(dir, srv.loader)
+	require.NoError(t, srv.workspace.Initialize())
+	docURI := uri.File(mainPath)
+	require.NoError(t, srv.DidOpen(context.Background(), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: docURI, Text: content},
+	}))
+
+	tokens := semanticTokensForDocument(t, srv, docURI)
+	declared := semanticTokenAt(tokens, 3, TokenTypeAccount)
+	require.NotNil(t, declared)
+	assert.Zero(t, declared.modifiers&(1<<ModifierUndeclared))
+	undeclared := semanticTokenAt(tokens, 2, TokenTypeAccount)
+	require.NotNil(t, undeclared)
+	assert.NotZero(t, undeclared.modifiers&(1<<ModifierUndeclared))
+	emojiPayee := semanticTokenAt(tokens, 1, TokenTypePayee)
+	require.NotNil(t, emojiPayee)
+	assert.Equal(t, uint32(7), emojiPayee.length, "token length must use UTF-16 code units")
+	for _, line := range []uint32{2, 3} {
+		for _, token := range semanticAmountTokensOnLine(tokens, line) {
+			assert.NotZero(t, token.modifiers&(1<<ModifierUnbalanced), "line %d", line)
+		}
+	}
+}
+
+func semanticTokensForDocument(t *testing.T, srv *Server, docURI uri.URI) []semanticToken {
+	t.Helper()
+	result, err := srv.SemanticTokensFull(context.Background(), &protocol.SemanticTokensParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+	})
+	require.NoError(t, err)
+	return decodeSemanticTokens(result.Data)
+}
+
+func decodeSemanticTokens(data []uint32) []semanticToken {
+	tokens := make([]semanticToken, 0, len(data)/5)
+	var line, col uint32
+	for index := 0; index+4 < len(data); index += 5 {
+		if data[index] != 0 {
+			line += data[index]
+			col = data[index+1]
+		} else {
+			col += data[index+1]
+		}
+		tokens = append(tokens, semanticToken{
+			line:      line,
+			col:       col,
+			length:    data[index+2],
+			tokenType: data[index+3],
+			modifiers: data[index+4],
+		})
+	}
+	return tokens
+}
+
+func semanticTokenAt(tokens []semanticToken, line, tokenType uint32) *semanticToken {
+	for index := range tokens {
+		if tokens[index].line == line && tokens[index].tokenType == tokenType {
+			return &tokens[index]
+		}
+	}
+	return nil
+}
+
+func semanticAmountTokensOnLine(tokens []semanticToken, line uint32) []semanticToken {
+	var result []semanticToken
+	for _, token := range tokens {
+		if token.line == line && token.tokenType == TokenTypeAmount {
+			result = append(result, token)
+		}
+	}
+	return result
+}
+
+func assertNoDiagnosticModifiers(t *testing.T, tokens []semanticToken) {
+	t.Helper()
+	for _, token := range tokens {
+		assert.Zero(t, token.modifiers&(1<<ModifierUndeclared))
+		assert.Zero(t, token.modifiers&(1<<ModifierUnbalanced))
+	}
 }


### PR DESCRIPTION
## Purpose

Expose existing undeclared-account and unbalanced-transaction analysis through semantic-token modifiers so editors can highlight these states before the diagnostic message is opened.

Closes #42.

## Changes

- append `undeclared` and `unbalanced` to the semantic-token modifier legend;
- enrich full and range semantic tokens from existing analyzer diagnostics;
- respect diagnostics settings, workspace declarations, balance tolerance, rules files, and oversized-file guards;
- preserve existing modifier bits and avoid repeated full token scans per diagnostic;
- filter range requests by line and character boundaries;
- document VS Code selectors for both modifiers.

## Verification

- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test -race ./...`
- `git diff --check`

## Ориентиры в коде

- `internal/server/semantic.go`
- `internal/server/semantic_test.go`
- `docs/vscode.md`
