### PR TITLE
fix(protocol): comply with LSP 3.18 lifecycle and capabilities

### DIFF
--- a/cmd/hledger-lsp/lifecycle.go
+++ b/cmd/hledger-lsp/lifecycle.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+)
+
+type lifecyclePhase int
+
+const (
+	lifecyclePhasePreInitialize lifecyclePhase = iota
+	lifecyclePhaseInitializing
+	lifecyclePhaseAwaitingInitialized
+	lifecyclePhaseReady
+	lifecyclePhaseShutdown
+	lifecyclePhaseRetryableInitializeFailed
+	lifecyclePhaseInitializeFailed
+)
+
+type lifecycleState struct {
+	mu            sync.Mutex
+	phase         lifecyclePhase
+	exitCodeValue int
+	exitSignal    bool
+	exitCh        chan struct{}
+}
+
+func newLifecycleState() *lifecycleState {
+	return &lifecycleState{
+		phase:         lifecyclePhasePreInitialize,
+		exitCodeValue: 1,
+		exitCh:        make(chan struct{}, 1),
+	}
+}
+
+func (s *lifecycleState) lifecycleMiddleware(next jsonrpc2.Handler) jsonrpc2.Handler {
+	return func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+		method := req.Method()
+
+		if method == protocol.MethodExit {
+			s.signalExit()
+			return nil, nil
+		}
+
+		if method == protocol.MethodInitialize {
+			return s.handleInitialize(next, ctx, req)
+		}
+
+		if method == protocol.MethodInitialized {
+			if req.IsCall() {
+				return nil, nil
+			}
+			if s.tryEnterReady() {
+				return next(ctx, req)
+			}
+			return nil, nil
+		}
+
+		if method == protocol.MethodCancelRequest && !req.IsCall() {
+			if !s.isReady() {
+				return nil, nil
+			}
+		}
+
+		if err := s.checkRequest(method, req.IsCall()); err != nil {
+			return nil, err
+		}
+
+		if method == protocol.MethodShutdown && req.IsCall() {
+			if !s.isReady() {
+				return nil, nil
+			}
+			s.markShutdown()
+			_, err := next(ctx, req)
+			return nil, err
+		}
+
+		if !s.isReadyForRequest(method, req.IsCall()) {
+			return nil, nil
+		}
+
+		return next(ctx, req)
+	}
+}
+
+func (s *lifecycleState) handleInitialize(next jsonrpc2.Handler, ctx context.Context, req *jsonrpc2.Request) (any, error) {
+	if !req.IsCall() {
+		return nil, nil
+	}
+
+	if err := s.startInitialize(); err != nil {
+		return nil, err
+	}
+
+	result, err := next(ctx, req)
+	s.finishInitialize(err)
+	return result, err
+}
+
+func lifecycleMiddleware(next jsonrpc2.Handler, state *lifecycleState) jsonrpc2.Handler {
+	return state.lifecycleMiddleware(next)
+}
+
+func (s *lifecycleState) signalExit() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	code := 1
+	if s.phase == lifecyclePhaseShutdown {
+		code = 0
+	}
+	s.exitSignal = true
+	s.exitCodeValue = code
+	select {
+	case s.exitCh <- struct{}{}:
+	default:
+	}
+}
+
+func (s *lifecycleState) exitSignalAndCode() (int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.exitSignal {
+		return 0, false
+	}
+	return s.exitCodeValue, true
+}
+
+func (s *lifecycleState) markShutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.phase = lifecyclePhaseShutdown
+	s.exitSignal = true
+	s.exitCodeValue = 0
+}
+
+func (s *lifecycleState) setIfTransition(from, to lifecyclePhase) bool {
+	if s.phase != from {
+		return false
+	}
+	s.phase = to
+	return true
+}
+
+func (s *lifecycleState) tryEnterReady() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.setIfTransition(lifecyclePhaseAwaitingInitialized, lifecyclePhaseReady)
+}
+
+func (s *lifecycleState) startInitialize() *jsonrpc2.Error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch s.phase {
+	case lifecyclePhasePreInitialize, lifecyclePhaseRetryableInitializeFailed:
+		s.phase = lifecyclePhaseInitializing
+		return nil
+	case lifecyclePhaseInitializing:
+		return jsonrpc2.NewError(jsonrpc2.InvalidRequest, "initialize already in progress")
+	case lifecyclePhaseAwaitingInitialized:
+		return jsonrpc2.NewError(jsonrpc2.InvalidRequest, "already initialized")
+	case lifecyclePhaseReady:
+		return jsonrpc2.NewError(jsonrpc2.InvalidRequest, "server already initialized")
+	case lifecyclePhaseShutdown:
+		return jsonrpc2.NewError(jsonrpc2.InvalidRequest, "server is shutting down")
+	case lifecyclePhaseInitializeFailed:
+		return jsonrpc2.NewError(jsonrpc2.InvalidRequest, "initialize already failed")
+	default:
+		return jsonrpc2.NewError(jsonrpc2.Code(protocol.ErrorCodesInvalidRequest), "initialize is unavailable")
+	}
+}
+
+func (s *lifecycleState) finishInitialize(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.phase != lifecyclePhaseInitializing {
+		return
+	}
+
+	if err == nil {
+		s.phase = lifecyclePhaseAwaitingInitialized
+		return
+	}
+
+	if isRetryableInitializeError(err) {
+		s.phase = lifecyclePhaseRetryableInitializeFailed
+		return
+	}
+
+	s.phase = lifecyclePhaseInitializeFailed
+}
+
+func (s *lifecycleState) checkRequest(method string, isCall bool) *jsonrpc2.Error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch s.phase {
+	case lifecyclePhasePreInitialize, lifecyclePhaseInitializing, lifecyclePhaseRetryableInitializeFailed, lifecyclePhaseInitializeFailed:
+		if isCall {
+			if method == protocol.MethodInitialized {
+				return nil
+			}
+			return jsonrpc2.NewError(jsonrpc2.Code(protocol.ErrorCodesServerNotInitialized), "server not initialized")
+		}
+		return nil
+
+	case lifecyclePhaseAwaitingInitialized:
+		if !isCall {
+			return nil
+		}
+		return jsonrpc2.NewError(jsonrpc2.InvalidRequest, "server not initialized")
+
+	case lifecyclePhaseShutdown:
+		if isCall {
+			return jsonrpc2.NewError(jsonrpc2.InvalidRequest, "server is shutting down")
+		}
+		return nil
+	case lifecyclePhaseReady:
+		return nil
+	}
+
+	return nil
+}
+
+func (s *lifecycleState) isReady() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.phase == lifecyclePhaseReady
+}
+
+func (s *lifecycleState) isReadyForRequest(method string, isCall bool) bool {
+	if isCall {
+		return true
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch s.phase {
+	case lifecyclePhaseReady:
+		return true
+	case lifecyclePhaseAwaitingInitialized:
+		return method == protocol.MethodInitialized
+	case lifecyclePhasePreInitialize, lifecyclePhaseInitializing, lifecyclePhaseRetryableInitializeFailed, lifecyclePhaseInitializeFailed, lifecyclePhaseShutdown:
+		return false
+	default:
+		return false
+	}
+}
+
+func isRetryableInitializeError(err error) bool {
+	var rpcErr *jsonrpc2.Error
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+	var initErr protocol.InitializeError
+	if err := protocol.Unmarshal(rpcErr.Data, &initErr); err != nil {
+		return false
+	}
+	return initErr.Retry
+}
+
+func waitForServerExit(conn jsonrpc2.Conn, state *lifecycleState) int {
+	for {
+		select {
+		case <-state.exitCh:
+			if code, ok := state.exitSignalAndCode(); ok {
+				return code
+			}
+		case <-conn.Done():
+			if code, ok := state.exitSignalAndCode(); ok {
+				return code
+			}
+			return exitCodeForConnErr(conn.Err())
+		}
+	}
+}
+
+func exitCodeForConnErr(err error) int {
+	if err == nil || errors.Is(err, io.EOF) {
+		return 0
+	}
+	return 1
+}

--- a/cmd/hledger-lsp/lifecycle_test.go
+++ b/cmd/hledger-lsp/lifecycle_test.go
@@ -1,0 +1,414 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+type lifecycleTestServer struct {
+	protocol.UnimplementedServer
+
+	mu                sync.Mutex
+	initializeCount   int
+	initializedCount  int
+	didOpenCount      int
+	completionCount   int
+	shutdownCount     int
+	initializeResult  *protocol.InitializeResult
+	initializeErrors  []error
+	initializeErrIdx  int
+	initializeBlocker chan struct{}
+	initializeStarted chan struct{}
+	shutdownErr       error
+	completionUnblock chan struct{}
+	completionErr     error
+}
+
+func (s *lifecycleTestServer) initializeNextError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.initializeErrIdx >= len(s.initializeErrors) {
+		return nil
+	}
+	err := s.initializeErrors[s.initializeErrIdx]
+	s.initializeErrIdx++
+	return err
+}
+
+func (s *lifecycleTestServer) Initialize(_ context.Context, _ *protocol.InitializeParams) (*protocol.InitializeResult, error) {
+	s.mu.Lock()
+	s.initializeCount++
+	result := s.initializeResult
+	s.mu.Unlock()
+
+	if s.initializeStarted != nil {
+		select {
+		case s.initializeStarted <- struct{}{}:
+		default:
+		}
+	}
+	if s.initializeBlocker != nil {
+		<-s.initializeBlocker
+	}
+
+	if err := s.initializeNextError(); err != nil {
+		return nil, err
+	}
+	if result != nil {
+		return result, nil
+	}
+	return &protocol.InitializeResult{
+		Capabilities: protocol.ServerCapabilities{},
+		ServerInfo: protocol.ServerInfo{
+			Name:    "test",
+			Version: protocol.NewOptional("test"),
+		},
+	}, nil
+}
+
+func (s *lifecycleTestServer) Initialized(context.Context, *protocol.InitializedParams) error {
+	s.mu.Lock()
+	s.initializedCount++
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *lifecycleTestServer) DidOpen(context.Context, *protocol.DidOpenTextDocumentParams) error {
+	s.mu.Lock()
+	s.didOpenCount++
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *lifecycleTestServer) Completion(ctx context.Context, _ *protocol.CompletionParams) (protocol.CompletionResult, error) {
+	s.mu.Lock()
+	s.completionCount++
+	s.mu.Unlock()
+
+	if s.completionUnblock != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.completionUnblock:
+		}
+	}
+
+	if s.completionErr != nil {
+		return nil, s.completionErr
+	}
+	return &protocol.CompletionList{}, nil
+}
+
+func (s *lifecycleTestServer) Shutdown(context.Context) error {
+	s.mu.Lock()
+	s.shutdownCount++
+	s.mu.Unlock()
+	return s.shutdownErr
+}
+
+func (s *lifecycleTestServer) snapshot() (initializeCount, initializedCount, didOpenCount, completionCount, shutdownCount int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.initializeCount, s.initializedCount, s.didOpenCount, s.completionCount, s.shutdownCount
+}
+
+func openLifecyclePair(t *testing.T, srv *lifecycleTestServer) (context.Context, jsonrpc2.Conn, jsonrpc2.Conn, protocol.Server, *lifecycleState, func()) {
+	t.Helper()
+
+	serverPipe, clientPipe := net.Pipe()
+	serverCtx, serverConn, _, state := newProtocolServerConnection(context.Background(), serverPipe, srv)
+	clientCtx, clientConn, client := protocol.NewClient(serverCtx, &testClient{}, jsonrpc2.NewStream(clientPipe))
+	cleanup := func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+		<-serverConn.Done()
+	}
+	return clientCtx, serverConn, clientConn, client, state, cleanup
+}
+
+func assertRPCCode(t *testing.T, err error, code jsonrpc2.Code) {
+	t.Helper()
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	assert.Equal(t, code, rpcErr.Code)
+}
+
+func completionParams(uriString string) *protocol.CompletionParams {
+	uriValue := uri.URI(uriString)
+	return &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: uriValue,
+			},
+			Position: protocol.Position{Line: 0, Character: 0},
+		},
+	}
+}
+
+func TestLSPWire_LifecycleBasics(t *testing.T) {
+	ctx := context.Background()
+	srv := &lifecycleTestServer{}
+	_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+	defer cleanup()
+
+	exitCode := make(chan int, 1)
+	go func() {
+		exitCode <- waitForServerExit(serverConn, state)
+	}()
+
+	_, err := client.Completion(ctx, completionParams("file:///wire-before-init.journal"))
+	assertRPCCode(t, err, jsonrpc2.Code(protocol.ErrorCodesServerNotInitialized))
+
+	require.NoError(t, client.DidOpen(ctx, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:        uri.URI("file:///wire-before-init.journal"),
+			Version:    1,
+			Text:       "",
+			LanguageID: "hledger",
+		},
+	}))
+	require.Eventually(t, func() bool {
+		_, _, didOpen, _, _ := srv.snapshot()
+		return didOpen == 0
+	}, time.Second, time.Millisecond)
+
+	_, err = client.Initialize(ctx, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	_, err = client.Completion(ctx, completionParams("file:///wire-before-init.journal"))
+	assertRPCCode(t, err, jsonrpc2.InvalidRequest)
+
+	require.NoError(t, client.Initialized(ctx, &protocol.InitializedParams{}))
+	_, err = client.Completion(ctx, completionParams("file:///wire-before-init.journal"))
+	require.NoError(t, err)
+	require.NoError(t, client.Initialized(ctx, &protocol.InitializedParams{}))
+
+	initializes, initialized, _, completions, shutdowns := srv.snapshot()
+	require.Equal(t, 1, initializes)
+	require.Equal(t, 1, initialized)
+	require.Equal(t, 1, completions)
+	require.Equal(t, 0, shutdowns)
+
+	require.NoError(t, client.Shutdown(ctx))
+	_, err = client.Completion(ctx, completionParams("file:///wire-before-init.journal"))
+	assertRPCCode(t, err, jsonrpc2.InvalidRequest)
+	err = client.Shutdown(ctx)
+	require.Error(t, err)
+	assertRPCCode(t, err, jsonrpc2.InvalidRequest)
+
+	require.NoError(t, client.Exit(ctx))
+	require.Equal(t, 0, <-exitCode)
+}
+
+func TestLSPWire_InitializeInProgress(t *testing.T) {
+	ctx := context.Background()
+	started := make(chan struct{}, 1)
+	block := make(chan struct{})
+	srv := &lifecycleTestServer{
+		initializeStarted: started,
+		initializeBlocker: block,
+	}
+	_, serverConn, _, client, _, cleanup := openLifecyclePair(t, srv)
+	defer cleanup()
+
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+		firstResult <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	secondResult := make(chan error, 1)
+	go func() {
+		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+		secondResult <- err
+	}()
+
+	requestResult := make(chan error, 1)
+	go func() {
+		_, err := client.Completion(ctx, completionParams("file:///wire-before-init.journal"))
+		requestResult <- err
+	}()
+
+	assertRPCCode(t, <-secondResult, jsonrpc2.Code(protocol.ErrorCodesInvalidRequest))
+	assertRPCCode(t, <-requestResult, jsonrpc2.Code(protocol.ErrorCodesServerNotInitialized))
+
+	close(block)
+	require.NoError(t, <-firstResult)
+	require.NoError(t, serverConn.Close())
+}
+
+func TestLSPWire_InitializeRetryPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-retry initialize error blocks retries", func(t *testing.T) {
+		srv := &lifecycleTestServer{
+			initializeErrors: []error{errors.New("fatal")},
+		}
+		_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+		defer cleanup()
+
+		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+		require.Error(t, err)
+		_, err = client.Initialize(ctx, &protocol.InitializeParams{})
+		assertRPCCode(t, err, jsonrpc2.Code(protocol.ErrorCodesInvalidRequest))
+
+		exitCode := make(chan int, 1)
+		go func() {
+			exitCode <- waitForServerExit(serverConn, state)
+		}()
+		require.NoError(t, client.Exit(ctx))
+		require.Equal(t, 1, <-exitCode)
+	})
+
+	t.Run("retryable initialize error allows second attempt", func(t *testing.T) {
+		retryRaw, marshalErr := protocol.Marshal(protocol.InitializeError{Retry: true})
+		require.NoError(t, marshalErr)
+		retryErr := jsonrpc2.NewError(jsonrpc2.InternalError, "retryable")
+		retryErr.Data = jsonrpc2.RawMessage(retryRaw)
+
+		srv := &lifecycleTestServer{
+			initializeErrors: []error{retryErr},
+		}
+		_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+		defer cleanup()
+
+		_, firstInitErr := client.Initialize(ctx, &protocol.InitializeParams{})
+		require.Error(t, firstInitErr)
+		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+		require.NoError(t, err)
+
+		exitCode := make(chan int, 1)
+		go func() {
+			exitCode <- waitForServerExit(serverConn, state)
+		}()
+		require.NoError(t, client.Exit(ctx))
+		require.Equal(t, 1, <-exitCode)
+	})
+}
+
+func TestWaitForServerExit(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("exit after shutdown uses 0", func(t *testing.T) {
+		srv := &lifecycleTestServer{
+			shutdownErr: errors.New("shutdown failed"),
+		}
+		_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+		defer cleanup()
+
+		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+		require.NoError(t, err)
+		require.NoError(t, client.Initialized(ctx, &protocol.InitializedParams{}))
+		err = client.Shutdown(ctx)
+		require.Error(t, err)
+
+		exitCode := make(chan int, 1)
+		go func() {
+			exitCode <- waitForServerExit(serverConn, state)
+		}()
+		require.NoError(t, client.Exit(ctx))
+		require.Equal(t, 0, <-exitCode)
+	})
+
+	t.Run("shutdown then peer close keeps code 0", func(t *testing.T) {
+		srv := &lifecycleTestServer{}
+		_, serverConn, clientConn, client, state, cleanup := openLifecyclePair(t, srv)
+		defer cleanup()
+
+		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+		require.NoError(t, err)
+		require.NoError(t, client.Initialized(ctx, &protocol.InitializedParams{}))
+		require.NoError(t, client.Shutdown(ctx))
+		require.NoError(t, clientConn.Close())
+
+		exitCode := make(chan int, 1)
+		go func() {
+			exitCode <- waitForServerExit(serverConn, state)
+		}()
+		require.Equal(t, 0, <-exitCode)
+	})
+
+	t.Run("exit with peer close without shutdown gives 1", func(t *testing.T) {
+		srv := &lifecycleTestServer{}
+		_, serverConn, clientConn, client, state, cleanup := openLifecyclePair(t, srv)
+		defer cleanup()
+
+		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+		require.NoError(t, err)
+		require.NoError(t, client.Initialized(ctx, &protocol.InitializedParams{}))
+
+		exitCode := make(chan int, 1)
+		go func() {
+			exitCode <- waitForServerExit(serverConn, state)
+		}()
+		require.NoError(t, client.Exit(ctx))
+		require.NoError(t, clientConn.Close())
+		require.Equal(t, 1, <-exitCode)
+	})
+
+	t.Run("peer EOF without exit uses conn fallback code 0", func(t *testing.T) {
+		_, serverConn, clientConn, _, state, cleanup := openLifecyclePair(t, &lifecycleTestServer{})
+		defer cleanup()
+
+		require.NoError(t, clientConn.Close())
+
+		exitCode := make(chan int, 1)
+		go func() {
+			exitCode <- waitForServerExit(serverConn, state)
+		}()
+		require.Equal(t, 0, <-exitCode)
+	})
+}
+
+func TestLSPWire_CancelThenNextRequest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	srv := &lifecycleTestServer{
+		completionUnblock: make(chan struct{}),
+	}
+	_, _, _, client, _, cleanup := openLifecyclePair(t, srv)
+	defer cleanup()
+
+	_, err := client.Initialize(ctx, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	require.NoError(t, client.Initialized(ctx, &protocol.InitializedParams{}))
+
+	blockErr := make(chan error, 1)
+	blockCtx, blockCancel := context.WithCancel(ctx)
+	go func() {
+		_, err := client.Completion(blockCtx, completionParams("file:///wire-cancel.journal"))
+		blockErr <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		_, _, _, completionCount, _ := srv.snapshot()
+		return completionCount > 0
+	}, time.Second, time.Millisecond)
+
+	blockCancel()
+	require.ErrorIs(t, <-blockErr, context.Canceled)
+
+	close(srv.completionUnblock)
+	_, err = client.Completion(context.Background(), completionParams("file:///wire-cancel.journal"))
+	require.NoError(t, err)
+}

--- a/cmd/hledger-lsp/lifecycle_test.go
+++ b/cmd/hledger-lsp/lifecycle_test.go
@@ -123,18 +123,18 @@ func (s *lifecycleTestServer) snapshot() (initializeCount, initializedCount, did
 	return s.initializeCount, s.initializedCount, s.didOpenCount, s.completionCount, s.shutdownCount
 }
 
-func openLifecyclePair(t *testing.T, srv *lifecycleTestServer) (context.Context, jsonrpc2.Conn, jsonrpc2.Conn, protocol.Server, *lifecycleState, func()) {
+func openLifecyclePair(t *testing.T, srv *lifecycleTestServer) (jsonrpc2.Conn, jsonrpc2.Conn, protocol.Server, *lifecycleState, func()) {
 	t.Helper()
 
 	serverPipe, clientPipe := net.Pipe()
 	serverCtx, serverConn, _, state := newProtocolServerConnection(context.Background(), serverPipe, srv)
-	clientCtx, clientConn, client := protocol.NewClient(serverCtx, &testClient{}, jsonrpc2.NewStream(clientPipe))
+	_, clientConn, client := protocol.NewClient(serverCtx, &testClient{}, jsonrpc2.NewStream(clientPipe))
 	cleanup := func() {
 		_ = clientConn.Close()
 		_ = serverConn.Close()
 		<-serverConn.Done()
 	}
-	return clientCtx, serverConn, clientConn, client, state, cleanup
+	return serverConn, clientConn, client, state, cleanup
 }
 
 func assertRPCCode(t *testing.T, err error, code jsonrpc2.Code) {
@@ -159,7 +159,7 @@ func completionParams(uriString string) *protocol.CompletionParams {
 func TestLSPWire_LifecycleBasics(t *testing.T) {
 	ctx := context.Background()
 	srv := &lifecycleTestServer{}
-	_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+	serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
 	defer cleanup()
 
 	exitCode := make(chan int, 1)
@@ -218,7 +218,7 @@ func TestLSPWire_InitializeInProgress(t *testing.T) {
 		initializeStarted: started,
 		initializeBlocker: block,
 	}
-	_, serverConn, _, client, _, cleanup := openLifecyclePair(t, srv)
+	serverConn, _, client, _, cleanup := openLifecyclePair(t, srv)
 	defer cleanup()
 
 	firstResult := make(chan error, 1)
@@ -263,7 +263,7 @@ func TestLSPWire_InitializeRetryPolicy(t *testing.T) {
 		srv := &lifecycleTestServer{
 			initializeErrors: []error{errors.New("fatal")},
 		}
-		_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+		serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
 		defer cleanup()
 
 		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
@@ -288,7 +288,7 @@ func TestLSPWire_InitializeRetryPolicy(t *testing.T) {
 		srv := &lifecycleTestServer{
 			initializeErrors: []error{retryErr},
 		}
-		_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+		serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
 		defer cleanup()
 
 		_, firstInitErr := client.Initialize(ctx, &protocol.InitializeParams{})
@@ -312,7 +312,7 @@ func TestWaitForServerExit(t *testing.T) {
 		srv := &lifecycleTestServer{
 			shutdownErr: errors.New("shutdown failed"),
 		}
-		_, serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
+		serverConn, _, client, state, cleanup := openLifecyclePair(t, srv)
 		defer cleanup()
 
 		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
@@ -331,7 +331,7 @@ func TestWaitForServerExit(t *testing.T) {
 
 	t.Run("shutdown then peer close keeps code 0", func(t *testing.T) {
 		srv := &lifecycleTestServer{}
-		_, serverConn, clientConn, client, state, cleanup := openLifecyclePair(t, srv)
+		serverConn, clientConn, client, state, cleanup := openLifecyclePair(t, srv)
 		defer cleanup()
 
 		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
@@ -349,7 +349,7 @@ func TestWaitForServerExit(t *testing.T) {
 
 	t.Run("exit with peer close without shutdown gives 1", func(t *testing.T) {
 		srv := &lifecycleTestServer{}
-		_, serverConn, clientConn, client, state, cleanup := openLifecyclePair(t, srv)
+		serverConn, clientConn, client, state, cleanup := openLifecyclePair(t, srv)
 		defer cleanup()
 
 		_, err := client.Initialize(ctx, &protocol.InitializeParams{})
@@ -366,7 +366,7 @@ func TestWaitForServerExit(t *testing.T) {
 	})
 
 	t.Run("peer EOF without exit uses conn fallback code 0", func(t *testing.T) {
-		_, serverConn, clientConn, _, state, cleanup := openLifecyclePair(t, &lifecycleTestServer{})
+		serverConn, clientConn, _, state, cleanup := openLifecyclePair(t, &lifecycleTestServer{})
 		defer cleanup()
 
 		require.NoError(t, clientConn.Close())
@@ -386,7 +386,7 @@ func TestLSPWire_CancelThenNextRequest(t *testing.T) {
 	srv := &lifecycleTestServer{
 		completionUnblock: make(chan struct{}),
 	}
-	_, _, _, client, _, cleanup := openLifecyclePair(t, srv)
+	_, _, client, _, cleanup := openLifecyclePair(t, srv)
 	defer cleanup()
 
 	_, err := client.Initialize(ctx, &protocol.InitializeParams{})

--- a/cmd/hledger-lsp/main.go
+++ b/cmd/hledger-lsp/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,34 +25,35 @@ func main() {
 	}
 
 	ctx := context.Background()
-	srv := server.NewServer()
-	_, conn, _ := newServerConnection(ctx, stdrwc{}, srv)
-	<-conn.Done()
-
-	if code := exitCodeForConnErr(conn.Err()); code != 0 {
+	srv := server.NewServerWithVersion(Version)
+	_, conn, _, lifecycleState := newServerConnection(ctx, stdrwc{}, srv)
+	code := waitForServerExit(conn, lifecycleState)
+	if code != 0 {
 		os.Exit(code)
 	}
 }
 
-func newServerConnection(ctx context.Context, rwc io.ReadWriteCloser, srv *server.Server) (context.Context, jsonrpc2.Conn, protocol.Client) {
-	return newProtocolServerConnection(ctx, rwc, newServerDispatcher(srv))
+func newServerConnection(ctx context.Context, rwc io.ReadWriteCloser, srv *server.Server) (context.Context, jsonrpc2.Conn, protocol.Client, *lifecycleState) {
+	return newProtocolServerConnection(ctx, rwc, srv)
 }
 
-func newProtocolServerConnection(ctx context.Context, rwc io.ReadWriteCloser, srv protocol.Server) (context.Context, jsonrpc2.Conn, protocol.Client) {
+func newProtocolServerConnection(ctx context.Context, rwc io.ReadWriteCloser, srv protocol.Server) (context.Context, jsonrpc2.Conn, protocol.Client, *lifecycleState) {
 	conn := jsonrpc2.NewConn(jsonrpc2.NewStream(rwc), jsonrpc2.WithCodec(lspCodec{}))
 	client := protocol.ClientDispatcher(conn)
 	ctx = protocol.WithClient(ctx, client)
 
+	lifecycleState := newLifecycleState()
 	serverHandler := protocol.ServerHandler(srv, jsonrpc2.MethodNotFoundHandler)
-	handler := protocol.CancelHandler(func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+	serverAsyncHandler := func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		if req.IsCall() {
 			jsonrpc2.Async(ctx)
 		}
 		return serverHandler(ctx, req)
-	})
-	conn.Go(ctx, handler)
+	}
+	handler := protocol.CancelHandler(serverAsyncHandler)
+	conn.Go(ctx, lifecycleMiddleware(handler, lifecycleState))
 
-	return ctx, conn, client
+	return ctx, conn, client, lifecycleState
 }
 
 type lspCodec struct{}
@@ -85,13 +84,6 @@ func (lspCodec) Unmarshal(data []byte, v any) error {
 	return protocol.Unmarshal(data, v)
 }
 
-func exitCodeForConnErr(err error) int {
-	if err == nil || errors.Is(err, io.EOF) {
-		return 0
-	}
-	return 1
-}
-
 type stdrwc struct{}
 
 func (stdrwc) Read(p []byte) (int, error) {
@@ -104,312 +96,4 @@ func (stdrwc) Write(p []byte) (int, error) {
 
 func (stdrwc) Close() error {
 	return nil
-}
-
-type serverDispatcher struct {
-	protocol.UnimplementedServer
-	srv *server.Server
-}
-
-func newServerDispatcher(srv *server.Server) protocol.Server {
-	return &serverDispatcher{srv: srv}
-}
-
-func (d *serverDispatcher) Initialize(ctx context.Context, params *protocol.InitializeParams) (*protocol.InitializeResult, error) {
-	if client, ok := protocol.ClientFromContext(ctx); ok {
-		d.srv.SetClient(client)
-	}
-	return d.srv.Initialize(ctx, params)
-}
-
-func (d *serverDispatcher) Initialized(ctx context.Context, params *protocol.InitializedParams) error {
-	return d.srv.Initialized(ctx, params)
-}
-
-func (d *serverDispatcher) Shutdown(ctx context.Context) error {
-	return d.srv.Shutdown(ctx)
-}
-
-func (d *serverDispatcher) Exit(ctx context.Context) error {
-	return d.srv.Exit(ctx)
-}
-
-func (d *serverDispatcher) WorkDoneProgressCancel(ctx context.Context, params *protocol.WorkDoneProgressCancelParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) LogTrace(ctx context.Context, params *protocol.LogTraceParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) SetTrace(ctx context.Context, params *protocol.SetTraceParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) Progress(ctx context.Context, params *protocol.ProgressParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) CodeAction(ctx context.Context, params *protocol.CodeActionParams) ([]protocol.CommandOrCodeAction, error) {
-	return d.srv.CodeAction(ctx, params)
-}
-
-func (d *serverDispatcher) CodeLens(ctx context.Context, params *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
-	return d.srv.CodeLens(ctx, params)
-}
-
-func (d *serverDispatcher) CodeLensResolve(ctx context.Context, params *protocol.CodeLens) (*protocol.CodeLens, error) {
-	return d.srv.CodeLensResolve(ctx, params)
-}
-
-func (d *serverDispatcher) ColorPresentation(ctx context.Context, params *protocol.ColorPresentationParams) ([]protocol.ColorPresentation, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) Completion(ctx context.Context, params *protocol.CompletionParams) (protocol.CompletionResult, error) {
-	result, err := d.srv.Completion(ctx, params)
-	return result, err
-}
-
-func (d *serverDispatcher) CompletionResolve(ctx context.Context, params *protocol.CompletionItem) (*protocol.CompletionItem, error) {
-	return d.srv.CompletionResolve(ctx, params)
-}
-
-func (d *serverDispatcher) Declaration(ctx context.Context, params *protocol.DeclarationParams) (protocol.DeclarationResult, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) Definition(ctx context.Context, params *protocol.DefinitionParams) (protocol.DefinitionResult, error) {
-	result, err := d.srv.Definition(ctx, params)
-	return protocol.LocationSlice(result), err
-}
-
-func (d *serverDispatcher) DidChange(ctx context.Context, params *protocol.DidChangeTextDocumentParams) error {
-	return d.srv.DidChange(ctx, params)
-}
-
-func (d *serverDispatcher) DidChangeConfiguration(ctx context.Context, params *protocol.DidChangeConfigurationParams) error {
-	return d.srv.DidChangeConfiguration(ctx, params)
-}
-
-func (d *serverDispatcher) DidChangeWatchedFiles(ctx context.Context, params *protocol.DidChangeWatchedFilesParams) error {
-	return d.srv.DidChangeWatchedFiles(ctx, params)
-}
-
-func (d *serverDispatcher) DidChangeWorkspaceFolders(ctx context.Context, params *protocol.DidChangeWorkspaceFoldersParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) DidClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
-	return d.srv.DidClose(ctx, params)
-}
-
-func (d *serverDispatcher) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
-	return d.srv.DidOpen(ctx, params)
-}
-
-func (d *serverDispatcher) DidSave(ctx context.Context, params *protocol.DidSaveTextDocumentParams) error {
-	return d.srv.DidSave(ctx, params)
-}
-
-func (d *serverDispatcher) DocumentColor(ctx context.Context, params *protocol.DocumentColorParams) ([]protocol.ColorInformation, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) DocumentHighlight(ctx context.Context, params *protocol.DocumentHighlightParams) ([]protocol.DocumentHighlight, error) {
-	return d.srv.DocumentHighlight(ctx, params)
-}
-
-func (d *serverDispatcher) DocumentLink(ctx context.Context, params *protocol.DocumentLinkParams) ([]protocol.DocumentLink, error) {
-	return d.srv.DocumentLink(ctx, params)
-}
-
-func (d *serverDispatcher) DocumentLinkResolve(ctx context.Context, params *protocol.DocumentLink) (*protocol.DocumentLink, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) (protocol.DocumentSymbolResult, error) {
-	result, err := d.srv.DocumentSymbol(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-
-	symbols := make(protocol.DocumentSymbolSlice, 0, len(result))
-	for _, symbol := range result {
-		documentSymbol, ok := symbol.(protocol.DocumentSymbol)
-		if !ok {
-			return nil, fmt.Errorf("unexpected document symbol type %T", symbol)
-		}
-		symbols = append(symbols, documentSymbol)
-	}
-	return symbols, nil
-}
-
-func (d *serverDispatcher) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCommandParams) (protocol.LSPAny, error) {
-	return d.srv.ExecuteCommand(ctx, params)
-}
-
-func (d *serverDispatcher) FoldingRanges(ctx context.Context, params *protocol.FoldingRangeParams) ([]protocol.FoldingRange, error) {
-	return d.srv.FoldingRanges(ctx, params)
-}
-
-func (d *serverDispatcher) Formatting(ctx context.Context, params *protocol.DocumentFormattingParams) ([]protocol.TextEdit, error) {
-	return d.srv.Format(ctx, params)
-}
-
-func (d *serverDispatcher) Hover(ctx context.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
-	return d.srv.Hover(ctx, params)
-}
-
-func (d *serverDispatcher) InlayHint(ctx context.Context, params *protocol.InlayHintParams) ([]protocol.InlayHint, error) {
-	return d.srv.InlayHint(ctx, params)
-}
-
-func (d *serverDispatcher) Implementation(ctx context.Context, params *protocol.ImplementationParams) (protocol.DefinitionResult, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) OnTypeFormatting(ctx context.Context, params *protocol.DocumentOnTypeFormattingParams) ([]protocol.TextEdit, error) {
-	return d.srv.OnTypeFormatting(ctx, params)
-}
-
-func (d *serverDispatcher) PrepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (protocol.PrepareRenameResult, error) {
-	result, err := d.srv.PrepareRename(ctx, params)
-	return result, err
-}
-
-func (d *serverDispatcher) RangeFormatting(ctx context.Context, params *protocol.DocumentRangeFormattingParams) ([]protocol.TextEdit, error) {
-	return d.srv.RangeFormat(ctx, params)
-}
-
-func (d *serverDispatcher) References(ctx context.Context, params *protocol.ReferenceParams) ([]protocol.Location, error) {
-	return d.srv.References(ctx, params)
-}
-
-func (d *serverDispatcher) Rename(ctx context.Context, params *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
-	return d.srv.Rename(ctx, params)
-}
-
-func (d *serverDispatcher) SignatureHelp(ctx context.Context, params *protocol.SignatureHelpParams) (*protocol.SignatureHelp, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) Symbols(ctx context.Context, params *protocol.WorkspaceSymbolParams) (protocol.WorkspaceSymbolResult, error) {
-	result, err := d.srv.WorkspaceSymbol(ctx, params)
-	return protocol.SymbolInformationSlice(result), err
-}
-
-func (d *serverDispatcher) TypeDefinition(ctx context.Context, params *protocol.TypeDefinitionParams) (protocol.DefinitionResult, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) WillSave(ctx context.Context, params *protocol.WillSaveTextDocumentParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) WillSaveWaitUntil(ctx context.Context, params *protocol.WillSaveTextDocumentParams) ([]protocol.TextEdit, error) {
-	return d.srv.WillSaveWaitUntil(ctx, params)
-}
-
-func (d *serverDispatcher) ShowDocument(ctx context.Context, params *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) WillCreateFiles(ctx context.Context, params *protocol.CreateFilesParams) (*protocol.WorkspaceEdit, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) DidCreateFiles(ctx context.Context, params *protocol.CreateFilesParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) WillRenameFiles(ctx context.Context, params *protocol.RenameFilesParams) (*protocol.WorkspaceEdit, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) DidRenameFiles(ctx context.Context, params *protocol.RenameFilesParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) WillDeleteFiles(ctx context.Context, params *protocol.DeleteFilesParams) (*protocol.WorkspaceEdit, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) DidDeleteFiles(ctx context.Context, params *protocol.DeleteFilesParams) error {
-	return nil
-}
-
-func (d *serverDispatcher) SemanticTokensFull(ctx context.Context, params *protocol.SemanticTokensParams) (*protocol.SemanticTokens, error) {
-	return d.srv.SemanticTokensFull(ctx, params)
-}
-
-func (d *serverDispatcher) SemanticTokensFullDelta(ctx context.Context, params *protocol.SemanticTokensDeltaParams) (protocol.SemanticTokensDeltaResult, error) {
-	// Delta is not advertised (Delta: false); clients should not call this.
-	// Fall back to a full response for safety.
-	result, err := d.srv.SemanticTokensFull(ctx, &protocol.SemanticTokensParams{
-		TextDocument: params.TextDocument,
-	})
-	return result, err
-}
-
-func (d *serverDispatcher) SemanticTokensRange(ctx context.Context, params *protocol.SemanticTokensRangeParams) (*protocol.SemanticTokens, error) {
-	return d.srv.SemanticTokensRange(ctx, params)
-}
-
-func (d *serverDispatcher) SemanticTokensRefresh(ctx context.Context) error {
-	return nil
-}
-
-func (d *serverDispatcher) LinkedEditingRange(ctx context.Context, params *protocol.LinkedEditingRangeParams) (*protocol.LinkedEditingRanges, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) Moniker(ctx context.Context, params *protocol.MonikerParams) ([]protocol.Moniker, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) PrepareCallHierarchy(ctx context.Context, params *protocol.CallHierarchyPrepareParams) ([]protocol.CallHierarchyItem, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) IncomingCalls(ctx context.Context, params *protocol.CallHierarchyIncomingCallsParams) ([]protocol.CallHierarchyIncomingCall, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) OutgoingCalls(ctx context.Context, params *protocol.CallHierarchyOutgoingCallsParams) ([]protocol.CallHierarchyOutgoingCall, error) {
-	return nil, nil
-}
-
-func (d *serverDispatcher) InlineCompletion(ctx context.Context, params *protocol.InlineCompletionParams) (protocol.InlineCompletionResult, error) {
-	return d.srv.InlineCompletion(ctx, params)
-}
-
-func (d *serverDispatcher) handlePayeeAccountHistory(ctx context.Context, params any) (any, error) {
-	rawParams, ok := params.(protocol.LSPAny)
-	if !ok {
-		return nil, fmt.Errorf("hledger/payeeAccountHistory params type = %T, want protocol.LSPAny", params)
-	}
-
-	var decoded server.PayeeAccountHistoryParams
-	if err := protocol.Unmarshal(rawParams, &decoded); err != nil {
-		return nil, err
-	}
-
-	return d.srv.PayeeAccountHistory(ctx, json.RawMessage(rawParams))
-}
-
-func (d *serverDispatcher) CodeLensRefresh(ctx context.Context) error {
-	return nil
-}
-
-func (d *serverDispatcher) SelectionRange(ctx context.Context, params *protocol.SelectionRangeParams) ([]protocol.SelectionRange, error) {
-	return d.srv.SelectionRange(ctx, params)
-}
-
-func (d *serverDispatcher) Request(ctx context.Context, method string, params any) (any, error) {
-	fmt.Fprintf(os.Stderr, "[LSP DEBUG] Request called: method=%s\n", method)
-	if method == "hledger/payeeAccountHistory" {
-		return d.handlePayeeAccountHistory(ctx, params)
-	}
-	return nil, nil
 }

--- a/cmd/hledger-lsp/main_test.go
+++ b/cmd/hledger-lsp/main_test.go
@@ -34,7 +34,9 @@ func TestLSPWire(t *testing.T) {
 		<-serverConn.Done()
 	})
 
-	initializeResult, err := clientServer.Initialize(ctx, &protocol.InitializeParams{})
+	initializeResult, err := clientServer.Initialize(ctx, &protocol.InitializeParams{
+		Capabilities: codeActionLiteralClientCapabilities(),
+	})
 	require.NoError(t, err)
 	require.NotNil(t, initializeResult.ServerInfo)
 	require.Equal(t, "hledger-lsp", initializeResult.ServerInfo.Name)
@@ -80,6 +82,11 @@ func TestLSPWire(t *testing.T) {
 `,
 		}},
 	}))
+
+	_, err = clientServer.Formatting(ctx, &protocol.DocumentFormattingParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: documentURI},
+	})
+	require.NoError(t, err)
 
 	completion, err := clientServer.Completion(ctx, &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -130,6 +137,118 @@ func TestLSPWire(t *testing.T) {
 		assert.Positive(t, version)
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for publishDiagnostics")
+	}
+}
+
+func codeActionLiteralClientCapabilities() protocol.ClientCapabilities {
+	hierarchicalDocumentSymbols := true
+
+	return protocol.ClientCapabilities{
+		TextDocument: &protocol.TextDocumentClientCapabilities{
+			CodeAction: &protocol.CodeActionClientCapabilities{
+				CodeActionLiteralSupport: protocol.ClientCodeActionLiteralOptions{
+					CodeActionKind: protocol.ClientCodeActionKindOptions{
+						ValueSet: []protocol.CodeActionKind{protocol.CodeActionKindQuickFix},
+					},
+				},
+			},
+			DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{
+				HierarchicalDocumentSymbolSupport: &hierarchicalDocumentSymbols,
+			},
+		},
+	}
+}
+
+func TestLSPWire_InitializeReportsRuntimeVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverPipe, clientPipe := net.Pipe()
+	srv := server.NewServerWithVersion("wire-test-version")
+	_, serverConn, _, _ := newServerConnection(ctx, serverPipe, srv)
+	_, clientConn, clientServer := protocol.NewClient(ctx, &testClient{}, jsonrpc2.NewStream(clientPipe))
+	t.Cleanup(func() {
+		require.NoError(t, clientConn.Close())
+		require.NoError(t, serverConn.Close())
+		<-clientConn.Done()
+		<-serverConn.Done()
+	})
+
+	result, err := clientServer.Initialize(ctx, &protocol.InitializeParams{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ServerInfo)
+	version, ok := result.ServerInfo.Version.Get()
+	require.True(t, ok)
+	require.Equal(t, "wire-test-version", version)
+}
+
+func TestLSPWire_CodeActionResultArmsMatchCapabilities(t *testing.T) {
+	tests := []struct {
+		name               string
+		capabilities       protocol.ClientCapabilities
+		wantCodeActionArms bool
+	}{
+		{
+			name:               "literal client",
+			capabilities:       codeActionLiteralClientCapabilities(),
+			wantCodeActionArms: true,
+		},
+		{
+			name: "command-only client",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			serverPipe, clientPipe := net.Pipe()
+			srv := server.NewServer()
+			_, serverConn, _, _ := newServerConnection(ctx, serverPipe, srv)
+			_, clientConn, clientServer := protocol.NewClient(ctx, &testClient{}, jsonrpc2.NewStream(clientPipe))
+			t.Cleanup(func() {
+				require.NoError(t, clientConn.Close())
+				require.NoError(t, serverConn.Close())
+				<-clientConn.Done()
+				<-serverConn.Done()
+			})
+
+			initializeResult, err := clientServer.Initialize(ctx, &protocol.InitializeParams{Capabilities: tt.capabilities})
+			require.NoError(t, err)
+			if tt.wantCodeActionArms {
+				require.IsType(t, &protocol.CodeActionOptions{}, initializeResult.Capabilities.CodeActionProvider)
+			} else {
+				assert.Equal(t, protocol.Boolean(true), initializeResult.Capabilities.CodeActionProvider)
+			}
+			require.NoError(t, clientServer.Initialized(ctx, &protocol.InitializedParams{}))
+
+			documentURI := uri.URI("file:///wire-code-action.journal")
+			require.NoError(t, clientServer.DidOpen(ctx, &protocol.DidOpenTextDocumentParams{
+				TextDocument: protocol.TextDocumentItem{
+					URI: documentURI,
+					Text: `2024-01-15 lunch
+    expenses:food  $10.00
+    assets:cash    $-9.00`,
+				},
+			}))
+
+			actions, err := clientServer.CodeAction(ctx, &protocol.CodeActionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: documentURI},
+				Context: protocol.CodeActionContext{Diagnostics: []protocol.Diagnostic{{
+					Code: protocol.String("UNBALANCED"),
+				}}},
+			})
+			require.NoError(t, err)
+			if tt.wantCodeActionArms {
+				require.NotEmpty(t, actions)
+			}
+			for _, action := range actions {
+				_, isCodeAction := action.(*protocol.CodeAction)
+				assert.Equal(t, tt.wantCodeActionArms, isCodeAction, "received %T", action)
+			}
+		})
 	}
 }
 
@@ -252,6 +371,10 @@ func (c *testClient) PublishDiagnostics(_ context.Context, params *protocol.Publ
 
 func TestProtocolServer_CodeAction_DelegatesToServer(t *testing.T) {
 	srv := server.NewServer()
+	_, err := srv.Initialize(context.Background(), &protocol.InitializeParams{
+		Capabilities: codeActionLiteralClientCapabilities(),
+	})
+	require.NoError(t, err)
 
 	documentURI := uri.URI("file:///test.journal")
 	srv.StoreDocument(documentURI, `2024-01-15 lunch

--- a/cmd/hledger-lsp/main_test.go
+++ b/cmd/hledger-lsp/main_test.go
@@ -25,7 +25,7 @@ func TestLSPWire(t *testing.T) {
 	serverPipe, clientPipe := net.Pipe()
 	srv := server.NewServer()
 	diagnostics := make(chan protocol.PublishDiagnosticsParams, 1)
-	_, serverConn, _ := newServerConnection(ctx, serverPipe, srv)
+	_, serverConn, _, _ := newServerConnection(ctx, serverPipe, srv)
 	_, clientConn, clientServer := protocol.NewClient(ctx, &testClient{diagnostics: diagnostics}, jsonrpc2.NewStream(clientPipe))
 	t.Cleanup(func() {
 		require.NoError(t, clientConn.Close())
@@ -144,7 +144,7 @@ func TestLSPWire_DidChangeCompletesBeforeInlineCompletion(t *testing.T) {
 		didChangeDone:    make(chan struct{}),
 		inlineStarted:    make(chan struct{}),
 	}
-	_, serverConn, _ := newProtocolServerConnection(ctx, serverPipe, server)
+	_, serverConn, _, _ := newProtocolServerConnection(ctx, serverPipe, server)
 	_, clientConn, clientServer := protocol.NewClient(ctx, &testClient{}, jsonrpc2.NewStream(clientPipe))
 	t.Cleanup(func() {
 		require.NoError(t, clientConn.Close())
@@ -152,6 +152,10 @@ func TestLSPWire_DidChangeCompletesBeforeInlineCompletion(t *testing.T) {
 		<-clientConn.Done()
 		<-serverConn.Done()
 	})
+
+	_, err := clientServer.Initialize(ctx, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	require.NoError(t, clientServer.Initialized(ctx, &protocol.InitializedParams{}))
 
 	documentURI := uri.URI("file:///ordering.journal")
 	require.NoError(t, clientServer.DidChange(ctx, &protocol.DidChangeTextDocumentParams{
@@ -215,6 +219,14 @@ func (s *blockingDidChangeServer) DidChange(_ context.Context, _ *protocol.DidCh
 	return nil
 }
 
+func (s *blockingDidChangeServer) Initialize(_ context.Context, _ *protocol.InitializeParams) (*protocol.InitializeResult, error) {
+	return &protocol.InitializeResult{}, nil
+}
+
+func (s *blockingDidChangeServer) Initialized(_ context.Context, _ *protocol.InitializedParams) error {
+	return nil
+}
+
 func (s *blockingDidChangeServer) InlineCompletion(_ context.Context, _ *protocol.InlineCompletionParams) (protocol.InlineCompletionResult, error) {
 	close(s.inlineStarted)
 	return &protocol.InlineCompletionList{}, nil
@@ -238,16 +250,15 @@ func (c *testClient) PublishDiagnostics(_ context.Context, params *protocol.Publ
 	return nil
 }
 
-func TestServerDispatcher_CodeAction_DelegatesToServer(t *testing.T) {
+func TestProtocolServer_CodeAction_DelegatesToServer(t *testing.T) {
 	srv := server.NewServer()
-	dispatcher := newServerDispatcher(srv)
 
 	documentURI := uri.URI("file:///test.journal")
 	srv.StoreDocument(documentURI, `2024-01-15 lunch
     expenses:food  $10.00
     assets:cash    $-9.00`)
 
-	actions, err := dispatcher.CodeAction(context.Background(), &protocol.CodeActionParams{
+	actions, err := srv.CodeAction(context.Background(), &protocol.CodeActionParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: documentURI},
 		Range: protocol.Range{
 			Start: protocol.Position{Line: 0, Character: 0},
@@ -269,27 +280,25 @@ func TestServerDispatcher_CodeAction_DelegatesToServer(t *testing.T) {
 	assert.True(t, foundQuickFix, "expected quickfix action in delegated response")
 }
 
-func TestServerDispatcher_ExecuteCommand_DelegatesToServer(t *testing.T) {
+func TestProtocolServer_ExecuteCommand_DelegatesToServer(t *testing.T) {
 	srv := server.NewServer()
-	dispatcher := newServerDispatcher(srv)
 
-	_, err := dispatcher.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{
+	_, err := srv.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{
 		Command: "unknown.command",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown command")
 }
 
-func TestServerDispatcher_Request_PayeeAccountHistoryUsesLSPAny(t *testing.T) {
+func TestProtocolServer_Request_PayeeAccountHistoryUsesLSPAny(t *testing.T) {
 	srv := server.NewServer()
-	dispatcher := newServerDispatcher(srv)
 
 	documentURI := uri.URI("file:///payee-history.journal")
 	srv.StoreDocument(documentURI, `2024-01-15 lunch
     expenses:food  $10.00
     assets:cash`)
 
-	result, err := dispatcher.Request(context.Background(), "hledger/payeeAccountHistory", protocol.LSPAny(`{"textDocument":{"uri":"file:///payee-history.journal"}}`))
+	result, err := srv.Request(context.Background(), "hledger/payeeAccountHistory", protocol.LSPAny(`{"textDocument":{"uri":"file:///payee-history.journal"}}`))
 	require.NoError(t, err)
 
 	history, ok := result.(*server.PayeeAccountHistoryResult)

--- a/internal/server/benchmark_test.go
+++ b/internal/server/benchmark_test.go
@@ -85,7 +85,7 @@ func BenchmarkCompletion_Account_Small(b *testing.B) {
 
 	ctx := context.Background()
 	for b.Loop() {
-		_, _ = srv.Completion(ctx, params)
+		_, _ = srv.completion(ctx, params)
 	}
 }
 
@@ -103,7 +103,7 @@ func BenchmarkCompletion_Account_Medium(b *testing.B) {
 
 	ctx := context.Background()
 	for b.Loop() {
-		_, _ = srv.Completion(ctx, params)
+		_, _ = srv.completion(ctx, params)
 	}
 }
 
@@ -121,7 +121,7 @@ func BenchmarkCompletion_Account_Large(b *testing.B) {
 
 	ctx := context.Background()
 	for b.Loop() {
-		_, _ = srv.Completion(ctx, params)
+		_, _ = srv.completion(ctx, params)
 	}
 }
 
@@ -139,7 +139,7 @@ func BenchmarkCompletion_Payee(b *testing.B) {
 
 	ctx := context.Background()
 	for b.Loop() {
-		_, _ = srv.Completion(ctx, params)
+		_, _ = srv.completion(ctx, params)
 	}
 }
 
@@ -161,7 +161,7 @@ func BenchmarkCompletion_Commodity(b *testing.B) {
 
 	ctx := context.Background()
 	for b.Loop() {
-		_, _ = srv.Completion(ctx, params)
+		_, _ = srv.completion(ctx, params)
 	}
 }
 

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -1,0 +1,52 @@
+package server
+
+import "go.lsp.dev/protocol"
+
+// clientCapabilities is the subset of client capabilities that shapes server
+// responses and feature behavior after initialization.
+type clientCapabilities struct {
+	supportsConfiguration               bool
+	supportsRenamePrepare               bool
+	supportsCodeActionLiterals          bool
+	supportsCodeActionIsPreferred       bool
+	supportsHierarchicalDocumentSymbols bool
+	supportsDynamicFileWatchers         bool
+	completionDocumentationFormats      []protocol.MarkupKind
+	hoverContentFormats                 []protocol.MarkupKind
+}
+
+func newClientCapabilities(capabilities protocol.ClientCapabilities) clientCapabilities {
+	profile := clientCapabilities{}
+
+	if workspace := capabilities.Workspace; workspace != nil {
+		profile.supportsConfiguration = boolValue(workspace.Configuration)
+		if watchedFiles := workspace.DidChangeWatchedFiles; watchedFiles != nil {
+			profile.supportsDynamicFileWatchers = boolValue(watchedFiles.DynamicRegistration)
+		}
+	}
+
+	if textDocument := capabilities.TextDocument; textDocument != nil {
+		if rename := textDocument.Rename; rename != nil {
+			profile.supportsRenamePrepare = boolValue(rename.PrepareSupport)
+		}
+		if codeAction := textDocument.CodeAction; codeAction != nil {
+			profile.supportsCodeActionLiterals = codeAction.CodeActionLiteralSupport.CodeActionKind.ValueSet != nil
+			profile.supportsCodeActionIsPreferred = boolValue(codeAction.IsPreferredSupport)
+		}
+		if documentSymbol := textDocument.DocumentSymbol; documentSymbol != nil {
+			profile.supportsHierarchicalDocumentSymbols = boolValue(documentSymbol.HierarchicalDocumentSymbolSupport)
+		}
+		if completion := textDocument.Completion; completion != nil && completion.CompletionItem != nil {
+			profile.completionDocumentationFormats = append([]protocol.MarkupKind(nil), completion.CompletionItem.DocumentationFormat...)
+		}
+		if hover := textDocument.Hover; hover != nil {
+			profile.hoverContentFormats = append([]protocol.MarkupKind(nil), hover.ContentFormat...)
+		}
+	}
+
+	return profile
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}

--- a/internal/server/capabilities_test.go
+++ b/internal/server/capabilities_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func TestServer_Initialize_CapabilityProfiles(t *testing.T) {
+	trueValue := true
+
+	tests := []struct {
+		name               string
+		capabilities       protocol.ClientCapabilities
+		wantRenameOptions  bool
+		wantCodeActionOpts bool
+		wantSnapshot       clientCapabilities
+	}{
+		{
+			name:         "minimal",
+			wantSnapshot: clientCapabilities{},
+		},
+		{
+			name: "full",
+			capabilities: protocol.ClientCapabilities{
+				Workspace: &protocol.WorkspaceClientCapabilities{
+					DidChangeWatchedFiles: &protocol.DidChangeWatchedFilesClientCapabilities{
+						DynamicRegistration: &trueValue,
+					},
+				},
+				TextDocument: &protocol.TextDocumentClientCapabilities{
+					Rename: &protocol.RenameClientCapabilities{PrepareSupport: &trueValue},
+					CodeAction: &protocol.CodeActionClientCapabilities{
+						CodeActionLiteralSupport: protocol.ClientCodeActionLiteralOptions{
+							CodeActionKind: protocol.ClientCodeActionKindOptions{
+								ValueSet: []protocol.CodeActionKind{protocol.CodeActionKindQuickFix},
+							},
+						},
+						IsPreferredSupport: &trueValue,
+					},
+					DocumentSymbol: &protocol.DocumentSymbolClientCapabilities{
+						HierarchicalDocumentSymbolSupport: &trueValue,
+					},
+					Completion: &protocol.CompletionClientCapabilities{
+						CompletionItem: &protocol.ClientCompletionItemOptions{
+							DocumentationFormat: []protocol.MarkupKind{protocol.MarkupKindMarkdown},
+						},
+					},
+					Hover: &protocol.HoverClientCapabilities{
+						ContentFormat: []protocol.MarkupKind{protocol.MarkupKindPlainText},
+					},
+				},
+			},
+			wantRenameOptions:  true,
+			wantCodeActionOpts: true,
+			wantSnapshot: clientCapabilities{
+				supportsRenamePrepare:               true,
+				supportsCodeActionLiterals:          true,
+				supportsCodeActionIsPreferred:       true,
+				supportsHierarchicalDocumentSymbols: true,
+				supportsDynamicFileWatchers:         true,
+				completionDocumentationFormats:      []protocol.MarkupKind{protocol.MarkupKindMarkdown},
+				hoverContentFormats:                 []protocol.MarkupKind{protocol.MarkupKindPlainText},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewServer()
+			result, err := srv.Initialize(context.Background(), &protocol.InitializeParams{Capabilities: tt.capabilities})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantSnapshot, srv.clientCapabilities)
+			assert.Empty(t, result.Capabilities.Experimental)
+			require.IsType(t, &protocol.InlineCompletionOptions{}, result.Capabilities.InlineCompletionProvider)
+
+			if tt.wantRenameOptions {
+				renameOptions, ok := result.Capabilities.RenameProvider.(*protocol.RenameOptions)
+				require.True(t, ok)
+				require.NotNil(t, renameOptions.PrepareProvider)
+				assert.True(t, *renameOptions.PrepareProvider)
+			} else {
+				assert.Equal(t, protocol.Boolean(true), result.Capabilities.RenameProvider)
+			}
+
+			if tt.wantCodeActionOpts {
+				codeActionOptions, ok := result.Capabilities.CodeActionProvider.(*protocol.CodeActionOptions)
+				require.True(t, ok)
+				assert.Equal(t, []protocol.CodeActionKind{protocol.CodeActionKindQuickFix, "source.hledger"}, codeActionOptions.CodeActionKinds)
+			} else {
+				assert.Equal(t, protocol.Boolean(true), result.Capabilities.CodeActionProvider)
+			}
+		})
+	}
+}

--- a/internal/server/code_action.go
+++ b/internal/server/code_action.go
@@ -51,17 +51,33 @@ func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionPara
 	}
 	quickFixes := s.getQuickFixCodeActions(params)
 
-	result := make([]protocol.CommandOrCodeAction, 0, len(actions)+len(quickFixes))
-	for i := range quickFixes {
-		result = append(result, &quickFixes[i])
-	}
-	for _, action := range actions {
-		a := action
-		a.Diagnostics = nil
-		result = append(result, &a)
+	generated := make([]protocol.CodeAction, 0, len(actions)+len(quickFixes))
+	generated = append(generated, quickFixes...)
+	generated = append(generated, actions...)
+	return s.codeActionResult(generated), nil
+}
+
+func (s *Server) codeActionResult(actions []protocol.CodeAction) []protocol.CommandOrCodeAction {
+	result := make([]protocol.CommandOrCodeAction, 0, len(actions))
+	if s.clientCapabilities.supportsCodeActionLiterals {
+		for _, action := range actions {
+			if !s.clientCapabilities.supportsCodeActionIsPreferred {
+				action.IsPreferred = nil
+			}
+			result = append(result, &action)
+		}
+		return result
 	}
 
-	return result, nil
+	for _, action := range actions {
+		if action.Command.Command == "" {
+			continue
+		}
+		command := action.Command
+		result = append(result, &command)
+	}
+
+	return result
 }
 
 func (s *Server) getQuickFixCodeActions(params *protocol.CodeActionParams) []protocol.CodeAction {

--- a/internal/server/code_action_quickfix_test.go
+++ b/internal/server/code_action_quickfix_test.go
@@ -15,7 +15,19 @@ import (
 func TestServer_Initialize_AdvertisesQuickFixCodeActions(t *testing.T) {
 	srv := NewServer()
 
-	result, err := srv.Initialize(context.Background(), &protocol.InitializeParams{})
+	result, err := srv.Initialize(context.Background(), &protocol.InitializeParams{
+		Capabilities: protocol.ClientCapabilities{
+			TextDocument: &protocol.TextDocumentClientCapabilities{
+				CodeAction: &protocol.CodeActionClientCapabilities{
+					CodeActionLiteralSupport: protocol.ClientCodeActionLiteralOptions{
+						CodeActionKind: protocol.ClientCodeActionKindOptions{
+							ValueSet: []protocol.CodeActionKind{protocol.CodeActionKindQuickFix},
+						},
+					},
+				},
+			},
+		},
+	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -29,6 +41,8 @@ func TestServer_Initialize_AdvertisesQuickFixCodeActions(t *testing.T) {
 func TestServer_CodeAction_QuickFixForUnbalancedFinalPosting(t *testing.T) {
 	ts := newTestServer()
 	ts.cliClient = nil
+	ts.clientCapabilities.supportsCodeActionLiterals = true
+	ts.clientCapabilities.supportsCodeActionIsPreferred = true
 
 	uri := uri.URI("file:///test.journal")
 	content := `2024-01-15 lunch
@@ -66,6 +80,7 @@ func TestServer_CodeAction_QuickFixForUnbalancedFinalPosting(t *testing.T) {
 func TestServer_CodeAction_QuickFixWithoutDiagnosticContext(t *testing.T) {
 	ts := newTestServer()
 	ts.cliClient = nil
+	ts.clientCapabilities.supportsCodeActionLiterals = true
 
 	uri := uri.URI("file:///test.journal")
 	content := `2024-01-15 lunch
@@ -543,6 +558,8 @@ skip 1`,
 }
 
 func codeActionsForDiagnostics(ts *testServer, uri uri.URI, diagnostics []protocol.Diagnostic) ([]protocol.CodeAction, error) {
+	ts.clientCapabilities.supportsCodeActionLiterals = true
+
 	rng := protocol.Range{}
 	if len(diagnostics) > 0 {
 		rng = diagnostics[0].Range

--- a/internal/server/code_action_test.go
+++ b/internal/server/code_action_test.go
@@ -153,6 +153,96 @@ func TestServer_CodeAction_WithCLI(t *testing.T) {
 	}
 }
 
+func TestServer_CodeAction_ResultArmsMatchClientCapabilities(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name               string
+		capabilities       protocol.ClientCapabilities
+		wantCodeActionArms bool
+		wantIsPreferred    bool
+		wantCodeActionOpts bool
+	}{
+		{
+			name:               "literal client with isPreferred support",
+			capabilities:       codeActionClientCapabilities(trueValue),
+			wantCodeActionArms: true,
+			wantIsPreferred:    true,
+			wantCodeActionOpts: true,
+		},
+		{
+			name:               "literal client without isPreferred support",
+			capabilities:       codeActionClientCapabilities(falseValue),
+			wantCodeActionArms: true,
+			wantCodeActionOpts: true,
+		},
+		{
+			name:               "command-only client",
+			wantCodeActionArms: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewServer()
+			srv.cliClient = &fakeCLIClient{available: true}
+			result, err := srv.Initialize(context.Background(), &protocol.InitializeParams{Capabilities: tt.capabilities})
+			require.NoError(t, err)
+
+			if tt.wantCodeActionOpts {
+				require.IsType(t, &protocol.CodeActionOptions{}, result.Capabilities.CodeActionProvider)
+			} else {
+				assert.Equal(t, protocol.Boolean(true), result.Capabilities.CodeActionProvider)
+			}
+
+			documentURI := uri.URI("file:///test.journal")
+			srv.StoreDocument(documentURI, `2024-01-15 lunch
+    expenses:food  $10.00
+    assets:cash    $-9.00`)
+			actions, err := srv.CodeAction(context.Background(), &protocol.CodeActionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: documentURI},
+				Range:        protocol.Range{},
+				Context: protocol.CodeActionContext{Diagnostics: []protocol.Diagnostic{{
+					Code: protocol.String("UNBALANCED"),
+				}}},
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, actions)
+
+			for _, action := range actions {
+				codeAction, isCodeAction := action.(*protocol.CodeAction)
+				if tt.wantCodeActionArms {
+					require.True(t, isCodeAction, "literal client received %T", action)
+					if codeAction.Kind != nil && *codeAction.Kind == protocol.CodeActionKindQuickFix {
+						assert.Equal(t, tt.wantIsPreferred, codeAction.IsPreferred != nil)
+					}
+					continue
+				}
+
+				assert.False(t, isCodeAction, "command-only client received %T", action)
+				_, isCommand := action.(*protocol.Command)
+				assert.True(t, isCommand, "command-only client received %T", action)
+			}
+		})
+	}
+}
+
+func codeActionClientCapabilities(isPreferred bool) protocol.ClientCapabilities {
+	return protocol.ClientCapabilities{
+		TextDocument: &protocol.TextDocumentClientCapabilities{
+			CodeAction: &protocol.CodeActionClientCapabilities{
+				CodeActionLiteralSupport: protocol.ClientCodeActionLiteralOptions{
+					CodeActionKind: protocol.ClientCodeActionKindOptions{
+						ValueSet: []protocol.CodeActionKind{protocol.CodeActionKindQuickFix},
+					},
+				},
+				IsPreferredSupport: &isPreferred,
+			},
+		},
+	}
+}
+
 func TestCommentLinePrefix(t *testing.T) {
 	tests := []struct {
 		line     string

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -58,7 +58,7 @@ var directiveCompletions = []directiveDef{
 	{"year", "year ", "Directive"},
 }
 
-func (s *Server) Completion(ctx context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error) {
+func (s *Server) completion(ctx context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error) {
 	doc, ok := s.GetDocument(params.TextDocument.URI)
 	if !ok {
 		return &protocol.CompletionList{Items: []protocol.CompletionItem{}}, nil

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -58,7 +58,7 @@ var directiveCompletions = []directiveDef{
 	{"year", "year ", "Directive"},
 }
 
-func (s *Server) completion(ctx context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error) {
+func (s *Server) completion(_ context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error) {
 	doc, ok := s.GetDocument(params.TextDocument.URI)
 	if !ok {
 		return &protocol.CompletionList{Items: []protocol.CompletionItem{}}, nil

--- a/internal/server/completion_resolve.go
+++ b/internal/server/completion_resolve.go
@@ -88,10 +88,7 @@ func (s *Server) CompletionResolve(_ context.Context, item *protocol.CompletionI
 	}
 
 	if documentation != "" {
-		item.Documentation = &protocol.MarkupContent{
-			Kind:  protocol.MarkupKindMarkdown,
-			Value: documentation,
-		}
+		item.Documentation = documentationMarkupContent(documentation, s.clientCapabilities.completionDocumentationFormats)
 	}
 
 	return item, nil

--- a/internal/server/completion_resolve_test.go
+++ b/internal/server/completion_resolve_test.go
@@ -42,6 +42,27 @@ func TestCompletionResolve_Account(t *testing.T) {
 	assert.NotNil(t, result.Documentation)
 }
 
+func TestCompletionResolve_UsesClientPreferredMarkup(t *testing.T) {
+	srv := NewServer()
+	srv.clientCapabilities.completionDocumentationFormats = []protocol.MarkupKind{protocol.MarkupKindPlainText, protocol.MarkupKindMarkdown}
+	content := `account expenses:food
+
+2024-01-15 grocery
+    expenses:food  $50
+    assets:cash  $-50`
+	uri := uri.URI("file:///test.journal")
+	srv.documents.Store(uri, content)
+
+	data := completionResolveData{Kind: "account", Label: "expenses:food", DocURI: uri}
+	item := &protocol.CompletionItem{Label: "expenses:food", Data: mustMarshalLSPAny(t, data)}
+
+	result, err := srv.CompletionResolve(context.Background(), item)
+	require.NoError(t, err)
+	contentResult := result.Documentation.(*protocol.MarkupContent)
+	assert.Equal(t, protocol.MarkupKindPlainText, contentResult.Kind)
+	assert.NotContains(t, contentResult.Value, "**")
+}
+
 func TestCompletionResolve_Payee(t *testing.T) {
 	srv := NewServer()
 	content := `2024-01-15 grocery

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -36,7 +36,7 @@ account expenses:food
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -73,7 +73,7 @@ func TestCompletion_AccountsShowUsageCount(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -121,7 +121,7 @@ func TestCompletion_PayeesShowUsageCount(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -165,7 +165,7 @@ account assets:cash
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -197,7 +197,7 @@ func TestCompletion_Payees(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -233,7 +233,7 @@ func TestCompletion_Commodities(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -255,7 +255,7 @@ func TestCompletion_EmptyDocument(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -277,7 +277,7 @@ func TestCompletion_DocumentNotFound(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Items)
@@ -306,7 +306,7 @@ account expenses:food
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Len(t, result.Items, 1)
@@ -416,7 +416,7 @@ func TestCompletion_TagNames(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -449,7 +449,7 @@ func TestCompletion_TagNames_NoDuplicates(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -486,7 +486,7 @@ func TestCompletion_TagValues(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -518,7 +518,7 @@ func TestCompletion_TagValues_OnlyForCurrentTag(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -584,7 +584,7 @@ func TestCompletion_Date_BuiltIn(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -620,7 +620,7 @@ func TestCompletion_Date_Historical(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -648,7 +648,7 @@ func TestCompletion_Date_UsesFileFormat(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -683,7 +683,7 @@ func TestCompletion_Date_UsesSlashSeparator(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -716,7 +716,7 @@ account expenses:food
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -751,7 +751,7 @@ func TestCompletion_Date_UsesDotSeparator(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -786,7 +786,7 @@ func TestCompletion_Date_WithoutLeadingZeros(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -825,7 +825,7 @@ func TestCompletion_Date_HistoricalUsesFileFormat(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -869,7 +869,7 @@ func TestCompletion_PayeeInsertsOnlyPayeeName(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -913,7 +913,7 @@ func TestCompletion_MultiplePayeesShowCounts(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -973,7 +973,7 @@ func TestCompletion_RankingByFrequency(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1029,7 +1029,7 @@ func TestCompletion_AccountsRankingByFrequency(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1101,7 +1101,7 @@ func TestCompletion_MaxResultsPreservesFrequent(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1149,7 +1149,7 @@ func TestCompletion_MaxResultsAccountsPreservesFrequent(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1218,7 +1218,7 @@ include transactions.journal`
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1251,7 +1251,7 @@ func TestCompletion_IsIncompleteAlwaysTrue(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1279,7 +1279,7 @@ func TestCompletion_FilterTextSameForAllItems(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) >= 2, "should have multiple completion items matching 'exp'")
@@ -1502,7 +1502,7 @@ func TestCompletion_FiltersAndSortsByFrequency(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1558,7 +1558,7 @@ func TestCompletion_ConsecutiveMatchBeforeSparse(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1672,7 +1672,7 @@ commodity RUB
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1702,7 +1702,7 @@ account `
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1730,7 +1730,7 @@ commodity U`
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -1790,7 +1790,7 @@ account expenses:food
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) > 0, "should have completion items")
@@ -1833,7 +1833,7 @@ func TestCompletion_AccountMidWord_ReplacesFullToken(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2027,7 +2027,7 @@ func TestCompletion_PayeeWithoutTemplate(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2065,7 +2065,7 @@ account expenses:food:groceries
 	uri := uri.URI("file:///test.journal")
 	srv.StoreDocument(uri, content)
 
-	result, err := srv.Completion(context.Background(), &protocol.CompletionParams{
+	result, err := srv.completion(context.Background(), &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 			Position:     protocol.Position{Line: 4, Character: 7},
@@ -2102,7 +2102,7 @@ func TestCompletion_ShowCountsDisabled(t *testing.T) {
 	uri := uri.URI("file:///test.journal")
 	srv.StoreDocument(uri, content)
 
-	result, err := srv.Completion(context.Background(), &protocol.CompletionParams{
+	result, err := srv.completion(context.Background(), &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 			Position:     protocol.Position{Line: 9, Character: 4},
@@ -2145,7 +2145,7 @@ func TestCompletion_Date_UsesNearbyFormat(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2278,7 +2278,7 @@ func TestCompletion_PartialDateReturnsDates(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) > 0, "should have completion items for partial date")
@@ -2322,7 +2322,7 @@ func TestCompletion_PartialDateOverridesFileFormat(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) > 0, "should have completion items when typing year prefix")
@@ -2362,7 +2362,7 @@ func TestCompletion_ShortDateKeepsShortFormat(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) > 0, "should have completion items for short date prefix")
@@ -2429,7 +2429,7 @@ commodity RUB
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2628,7 +2628,7 @@ func TestCompletion_PayeeWithTab(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2861,7 +2861,7 @@ func TestCompletion_IncludeNotes_True_ShowsFullDescription(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2895,7 +2895,7 @@ func TestCompletion_IncludeNotes_False_ShowsPayeeOnly(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2926,7 +2926,7 @@ func TestCompletion_IncludeNotes_DefaultTrue(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2955,7 +2955,7 @@ func TestCompletion_ExcludesCurrentTransactionAccounts(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -2983,7 +2983,7 @@ func TestCompletion_ExcludesCurrentTransactionPayee(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3014,7 +3014,7 @@ func TestCompletion_CursorBetweenTransactions(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3049,7 +3049,7 @@ account assets:cash
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3115,7 +3115,7 @@ func TestRulesCompletion_HasTextEdit(t *testing.T) {
 			Position:     protocol.Position{Line: 0, Character: 6},
 		},
 	}
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Items)
@@ -3136,7 +3136,7 @@ func TestRulesCompletion_TextEditRange(t *testing.T) {
 			Position:     protocol.Position{Line: 0, Character: 6},
 		},
 	}
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Items)
@@ -3158,7 +3158,7 @@ func TestRulesCompletion_TextEditRange_TopLevel(t *testing.T) {
 			Position:     protocol.Position{Line: 0, Character: 3},
 		},
 	}
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Items)
@@ -3183,7 +3183,7 @@ func TestRulesCompletion_InsideIfBlock_FieldReferences(t *testing.T) {
 			Position:     protocol.Position{Line: 2, Character: 2},
 		},
 	}
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Items)
@@ -3221,7 +3221,7 @@ func TestRulesCompletion_InsideIfBlock_NoFieldsDeclared(t *testing.T) {
 			Position:     protocol.Position{Line: 1, Character: 2},
 		},
 	}
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Items)
@@ -3249,7 +3249,7 @@ func TestRulesCompletion_TopLevelStillOffersDirectives(t *testing.T) {
 			Position:     protocol.Position{Line: 0, Character: 3},
 		},
 	}
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Items)
@@ -3284,7 +3284,7 @@ func TestCompletion_DigitTriggerOnEmptyLine(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) > 0, "digit trigger should produce date completions")
@@ -3318,7 +3318,7 @@ func TestCompletion_DigitTriggerPartialYear(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) > 0, "digit trigger on partial year should produce date completions")
@@ -3353,7 +3353,7 @@ func TestCompletion_DigitTriggerInPostingDoesNotReturnDates(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3380,7 +3380,7 @@ func TestCompletion_DigitTriggerInPayeeArea(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3407,7 +3407,7 @@ func TestCompletion_DigitTriggerOnEmptyDocument(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, len(result.Items) > 0, "digit trigger on empty document should produce date completions")
@@ -3503,7 +3503,7 @@ func TestCompletion_Directive_TypingAccProducesAccount(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3536,7 +3536,7 @@ func TestCompletion_Directive_InsertTextHasTrailingSpace(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3564,7 +3564,7 @@ func TestCompletion_Directive_TextEditFromColumnZero(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3594,7 +3594,7 @@ func TestCompletion_Directive_FuzzyFiltering(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3620,7 +3620,7 @@ func TestCompletion_Directive_AllDirectivesShownOnSingleLetter(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3645,7 +3645,7 @@ func TestCompletion_Directive_MultiWordDirective(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3704,7 +3704,7 @@ func TestCompletion_Directive_CRLF(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3727,7 +3727,7 @@ func TestCompletion_Directive_BlockDirectiveNewlineInsertText(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3755,7 +3755,7 @@ func TestCompletion_Directive_TextEditCoversFullLine(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3798,7 +3798,7 @@ func TestCompletion_TagName_TextEditRange(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3839,7 +3839,7 @@ func TestCompletion_TagValue_TextEditRange(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3874,7 +3874,7 @@ func TestCompletion_TagName_FuzzyMatch(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3966,7 +3966,7 @@ func TestCompletion_TagName_CRLF(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3989,7 +3989,7 @@ func TestCompletion_TagValue_CRLF(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -4017,7 +4017,7 @@ func TestCompletion_TagName_PostingComment(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -4048,7 +4048,7 @@ func TestCompletion_TagValue_PostingComment(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -4112,7 +4112,7 @@ func TestCompletion_PayeeAwareAccountRanking(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -4162,7 +4162,7 @@ func TestCompletion_PayeeAwareRanking_UnknownPayeeFallsBackToGlobal(t *testing.T
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -4216,7 +4216,7 @@ func TestCompletion_PayeeAwareRanking_RecencyTiebreaker(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/internal/server/definition.go
+++ b/internal/server/definition.go
@@ -26,7 +26,7 @@ type definitionTarget struct {
 	symbolRange *protocol.Range
 }
 
-func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionParams) ([]protocol.Location, error) {
+func (s *Server) definition(ctx context.Context, params *protocol.DefinitionParams) ([]protocol.Location, error) {
 	doc, ok := s.getJournalDoc(params.TextDocument.URI)
 	if !ok {
 		return nil, nil

--- a/internal/server/definition.go
+++ b/internal/server/definition.go
@@ -26,7 +26,7 @@ type definitionTarget struct {
 	symbolRange *protocol.Range
 }
 
-func (s *Server) definition(ctx context.Context, params *protocol.DefinitionParams) ([]protocol.Location, error) {
+func (s *Server) definition(_ context.Context, params *protocol.DefinitionParams) ([]protocol.Location, error) {
 	doc, ok := s.getJournalDoc(params.TextDocument.URI)
 	if !ok {
 		return nil, nil

--- a/internal/server/definition_test.go
+++ b/internal/server/definition_test.go
@@ -30,7 +30,7 @@ func TestDefinition_AccountDirective(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -60,7 +60,7 @@ func TestDefinition_AccountFallback(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -89,7 +89,7 @@ func TestDefinition_CommodityDirective(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -119,7 +119,7 @@ func TestDefinition_Payee(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -145,7 +145,7 @@ func TestDefinition_UnknownPosition(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	assert.Empty(t, result) // empty response, no error
 }
@@ -162,7 +162,7 @@ func TestDefinition_DocumentNotFound(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -188,7 +188,7 @@ func TestDefinition_CommodityOnRight(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -214,7 +214,7 @@ func TestDefinition_CursorOnAccountDirective(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, uint32(0), result[0].Range.Start.Line)
@@ -239,7 +239,7 @@ func TestDefinition_CursorOnCommodityDirective(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, uint32(0), result[0].Range.Start.Line)
@@ -263,7 +263,7 @@ func TestDefinition_CursorOnPayeeDirective(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, uint32(2), result[0].Range.Start.Line) // first transaction usage
@@ -290,14 +290,14 @@ func TestDefinition_AccountBoundary(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Definition(context.Background(), params)
+	result, err := srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, uint32(0), result[0].Range.Start.Line)
 
 	// Test cursor at end of account name
 	params.Position = protocol.Position{Line: 3, Character: 16} // at end of "expenses:food"
-	result, err = srv.Definition(context.Background(), params)
+	result, err = srv.definition(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, uint32(0), result[0].Range.Start.Line)

--- a/internal/server/documentation.go
+++ b/internal/server/documentation.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"strings"
+
+	"go.lsp.dev/protocol"
+)
+
+func documentationMarkupContent(value string, formats []protocol.MarkupKind) *protocol.MarkupContent {
+	kind := preferredMarkupKind(formats)
+	if kind == protocol.MarkupKindPlainText {
+		value = plainTextDocumentation(value)
+	}
+	return &protocol.MarkupContent{Kind: kind, Value: value}
+}
+
+func preferredMarkupKind(formats []protocol.MarkupKind) protocol.MarkupKind {
+	for _, kind := range formats {
+		switch kind {
+		case protocol.MarkupKindMarkdown, protocol.MarkupKindPlainText:
+			return kind
+		}
+	}
+	return protocol.MarkupKindPlainText
+}
+
+func plainTextDocumentation(value string) string {
+	value = strings.ReplaceAll(value, "**", "")
+	value = strings.ReplaceAll(value, "`", "")
+	return strings.ReplaceAll(value, "*(empty)*", "(empty)")
+}

--- a/internal/server/documentation_test.go
+++ b/internal/server/documentation_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.lsp.dev/protocol"
+)
+
+func TestDocumentationMarkupContent_UsesFirstRecognizedFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		formats []protocol.MarkupKind
+		want    protocol.MarkupKind
+	}{
+		{
+			name:    "markdown first",
+			formats: []protocol.MarkupKind{protocol.MarkupKindMarkdown, protocol.MarkupKindPlainText},
+			want:    protocol.MarkupKindMarkdown,
+		},
+		{
+			name:    "plaintext first",
+			formats: []protocol.MarkupKind{protocol.MarkupKindPlainText, protocol.MarkupKindMarkdown},
+			want:    protocol.MarkupKindPlainText,
+		},
+		{
+			name: "empty defaults to plaintext",
+			want: protocol.MarkupKindPlainText,
+		},
+		{
+			name:    "unknown defaults to plaintext",
+			formats: []protocol.MarkupKind{"html"},
+			want:    protocol.MarkupKindPlainText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := documentationMarkupContent("**Label:** `value`\n*(empty)*", tt.formats)
+
+			assert.Equal(t, tt.want, content.Kind)
+		})
+	}
+}
+
+func TestDocumentationMarkupContent_PlainTextRemovesOnlySupportedMarkdownMarkers(t *testing.T) {
+	content := documentationMarkupContent("**Label:** `value`\n*(empty)*\n- preserve *list*", []protocol.MarkupKind{protocol.MarkupKindPlainText})
+
+	assert.Equal(t, protocol.MarkupKindPlainText, content.Kind)
+	assert.Equal(t, "Label: value\n(empty)\n- preserve *list*", content.Value)
+}

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -86,11 +86,8 @@ func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (*prot
 	}
 
 	return &protocol.Hover{
-		Contents: &protocol.MarkupContent{
-			Kind:  protocol.MarkupKindMarkdown,
-			Value: content,
-		},
-		Range: astRangeToProtocol(element.rng),
+		Contents: documentationMarkupContent(content, s.clientCapabilities.hoverContentFormats),
+		Range:    astRangeToProtocol(element.rng),
 	}, nil
 }
 

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/juev/hledger-lsp/internal/formatter"
 )
 
+func newMarkdownHoverServer() *Server {
+	srv := NewServer()
+	srv.clientCapabilities.hoverContentFormats = []protocol.MarkupKind{protocol.MarkupKindMarkdown}
+	return srv
+}
+
 func TestPositionInRange(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -122,6 +128,26 @@ func TestHover_Account(t *testing.T) {
 
 	assert.Contains(t, hoverContent(result), "expenses:food")
 	assert.Contains(t, hoverContent(result), "80")
+}
+
+func TestHover_UsesClientPreferredMarkup(t *testing.T) {
+	srv := NewServer()
+	srv.clientCapabilities.hoverContentFormats = []protocol.MarkupKind{protocol.MarkupKindPlainText, protocol.MarkupKindMarkdown}
+	srv.documents.Store(uri.URI("file:///test.journal"), `2024-01-15 grocery
+    expenses:food  $50
+    assets:cash  $-50`)
+
+	result, err := srv.Hover(context.Background(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.journal"},
+			Position:     protocol.Position{Line: 1, Character: 10},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	content := result.Contents.(*protocol.MarkupContent)
+	assert.Equal(t, protocol.MarkupKindPlainText, content.Kind)
+	assert.NotContains(t, content.Value, "**")
 }
 
 func TestHover_Amount(t *testing.T) {
@@ -399,7 +425,7 @@ func TestHover_TagWithValuesListed(t *testing.T) {
 }
 
 func TestHover_TagWithEmptyValue(t *testing.T) {
-	srv := NewServer()
+	srv := newMarkdownHoverServer()
 	content := `2024-01-15 grocery ; completed:
     expenses:food  $50
     assets:cash`
@@ -426,7 +452,7 @@ func TestHover_TagWithEmptyValue(t *testing.T) {
 }
 
 func TestHover_TagValueEmpty(t *testing.T) {
-	srv := NewServer()
+	srv := newMarkdownHoverServer()
 	content := `2024-01-15 grocery ; done:
     expenses:food  $50
     assets:cash`
@@ -1059,7 +1085,7 @@ func TestHover_AccountBalanceNoDefaultCommodityKeepsSeparate(t *testing.T) {
 }
 
 func TestHover_AccountBalanceDecimalPrecision(t *testing.T) {
-	srv := NewServer()
+	srv := newMarkdownHoverServer()
 	content := `2024-01-15 grocery
     expenses:food  25.70 USD
     assets:cash  -25.70 USD

--- a/internal/server/integration_include_test.go
+++ b/internal/server/integration_include_test.go
@@ -424,7 +424,7 @@ account Expenses:Occasions
 	// Total Assets:Cash: main(-25.70 + -18.00) + records(-25.70 + -9.00 + -6.20 + -5.00 + -17.70 + -7.80)
 	// = -43.70 + -71.40 = -115.10, 8 postings
 	assert.Contains(t, hoverContent, "115.10", "balance should include all postings from both files")
-	assert.Contains(t, hoverContent, "Postings:** 8", "should count all 8 postings across both files")
+	assert.Contains(t, hoverContent, "Postings: 8", "should count all 8 postings across both files")
 }
 
 func TestIntegration_Issue18_CRLFIncludedFile(t *testing.T) {
@@ -470,7 +470,7 @@ account Expenses:Occasions
 
 	assert.Contains(t, hoverContent, "Assets:Cash")
 	assert.Contains(t, hoverContent, "115.10", "balance should be correct even with CRLF included file")
-	assert.Contains(t, hoverContent, "Postings:** 8", "should count all 8 postings even with CRLF included file")
+	assert.Contains(t, hoverContent, "Postings: 8", "should count all 8 postings even with CRLF included file")
 }
 
 func TestIntegration_Issue18_WorkspaceFolderMode(t *testing.T) {
@@ -523,7 +523,7 @@ func TestIntegration_Issue18_WorkspaceFolderMode(t *testing.T) {
 	// main: -25.70 + -18.00 = -43.70 (2 postings)
 	// records: -25.70 + -9.00 + -6.20 = -40.90 (3 postings)
 	// Total: -84.60, 5 postings
-	assert.Contains(t, hoverContent, "Postings:** 5", "workspace mode should aggregate postings from included files")
+	assert.Contains(t, hoverContent, "Postings: 5", "workspace mode should aggregate postings from included files")
 }
 
 func TestIntegration_Issue18_GlobIncludeWithSubdirectory(t *testing.T) {
@@ -584,7 +584,7 @@ func TestIntegration_Issue18_GlobIncludeWithSubdirectory(t *testing.T) {
 
 	assert.Contains(t, hoverContent, "Assets:Cash")
 	assert.Contains(t, hoverContent, "115.10", "balance should include all postings from both files")
-	assert.Contains(t, hoverContent, "Postings:** 8", "should count all 8 postings across both files")
+	assert.Contains(t, hoverContent, "Postings: 8", "should count all 8 postings across both files")
 }
 
 func TestIntegration_JournalIncludesRulesFile(t *testing.T) {

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -311,7 +311,7 @@ func TestIntegration_DocumentSymbols(t *testing.T) {
 	params := &protocol.DocumentSymbolParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	symbols, err := ts.DocumentSymbol(context.Background(), params)
+	symbols, err := ts.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(symbols), 2, "month group + account directive")
 }

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -311,8 +311,7 @@ func TestIntegration_DocumentSymbols(t *testing.T) {
 	params := &protocol.DocumentSymbolParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	symbols, err := ts.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	symbols := ts.documentSymbols(context.Background(), params)
 	require.GreaterOrEqual(t, len(symbols), 2, "month group + account directive")
 }
 

--- a/internal/server/payee_history.go
+++ b/internal/server/payee_history.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 
 	"go.lsp.dev/protocol"
 )
@@ -16,13 +15,8 @@ type PayeeAccountHistoryResult struct {
 	PairUsage     map[string]int      `json:"pairUsage"`
 }
 
-func (s *Server) PayeeAccountHistory(_ context.Context, params json.RawMessage) (*PayeeAccountHistoryResult, error) {
-	var p PayeeAccountHistoryParams
-	if err := json.Unmarshal(params, &p); err != nil {
-		return nil, err
-	}
-
-	content, ok := s.GetDocument(p.TextDocument.URI)
+func (s *Server) PayeeAccountHistory(_ context.Context, params *PayeeAccountHistoryParams) (*PayeeAccountHistoryResult, error) {
+	content, ok := s.GetDocument(params.TextDocument.URI)
 	if !ok {
 		return &PayeeAccountHistoryResult{
 			PayeeAccounts: make(map[string][]string),
@@ -30,7 +24,7 @@ func (s *Server) PayeeAccountHistory(_ context.Context, params json.RawMessage) 
 		}, nil
 	}
 
-	if resolved := s.getWorkspaceResolved(p.TextDocument.URI); resolved != nil {
+	if resolved := s.getWorkspaceResolved(params.TextDocument.URI); resolved != nil {
 		result := s.analyzer.AnalyzeResolved(resolved)
 		return &PayeeAccountHistoryResult{
 			PayeeAccounts: result.PayeeAccounts,
@@ -38,7 +32,7 @@ func (s *Server) PayeeAccountHistory(_ context.Context, params json.RawMessage) 
 		}, nil
 	}
 
-	journal, errs := s.cachedJournal(p.TextDocument.URI, content)
+	journal, errs := s.cachedJournal(params.TextDocument.URI, content)
 	if len(errs) > 0 || journal == nil {
 		return &PayeeAccountHistoryResult{
 			PayeeAccounts: make(map[string][]string),

--- a/internal/server/payee_history_test.go
+++ b/internal/server/payee_history_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,13 +20,10 @@ func TestPayeeAccountHistory_EmptyJournal(t *testing.T) {
 
 	srv.documents.Store(uri, content)
 
-	params := PayeeAccountHistoryParams{
+	params := &PayeeAccountHistoryParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
-
-	result, err := srv.PayeeAccountHistory(context.Background(), paramsJSON)
+	result, err := srv.PayeeAccountHistory(context.Background(), params)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -47,13 +43,10 @@ func TestPayeeAccountHistory_SinglePayee(t *testing.T) {
 
 	srv.documents.Store(uri, content)
 
-	params := PayeeAccountHistoryParams{
+	params := &PayeeAccountHistoryParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
-
-	result, err := srv.PayeeAccountHistory(context.Background(), paramsJSON)
+	result, err := srv.PayeeAccountHistory(context.Background(), params)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -83,13 +76,10 @@ func TestPayeeAccountHistory_MultiplePayees(t *testing.T) {
 
 	srv.documents.Store(uri, content)
 
-	params := PayeeAccountHistoryParams{
+	params := &PayeeAccountHistoryParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
-
-	result, err := srv.PayeeAccountHistory(context.Background(), paramsJSON)
+	result, err := srv.PayeeAccountHistory(context.Background(), params)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -121,13 +111,10 @@ func TestPayeeAccountHistory_FrequentAccounts(t *testing.T) {
 
 	srv.documents.Store(uri, content)
 
-	params := PayeeAccountHistoryParams{
+	params := &PayeeAccountHistoryParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
-
-	result, err := srv.PayeeAccountHistory(context.Background(), paramsJSON)
+	result, err := srv.PayeeAccountHistory(context.Background(), params)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -155,13 +142,10 @@ func TestPayeeAccountHistory_Unicode(t *testing.T) {
 
 	srv.documents.Store(uri, content)
 
-	params := PayeeAccountHistoryParams{
+	params := &PayeeAccountHistoryParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
-
-	result, err := srv.PayeeAccountHistory(context.Background(), paramsJSON)
+	result, err := srv.PayeeAccountHistory(context.Background(), params)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -170,30 +154,16 @@ func TestPayeeAccountHistory_Unicode(t *testing.T) {
 	assert.Equal(t, 1, result.PairUsage["Пятёрочка::expenses:food"])
 }
 
-func TestPayeeAccountHistory_InvalidJSON(t *testing.T) {
-	srv := NewServer()
-	client := &mockClient{}
-	srv.SetClient(client)
-
-	result, err := srv.PayeeAccountHistory(context.Background(), json.RawMessage(`{invalid}`))
-
-	assert.Error(t, err)
-	assert.Nil(t, result)
-}
-
 func TestPayeeAccountHistory_UnknownDocument(t *testing.T) {
 	srv := NewServer()
 	client := &mockClient{}
 	srv.SetClient(client)
 
 	uri := uri.URI("file:///unknown.journal")
-	params := PayeeAccountHistoryParams{
+	params := &PayeeAccountHistoryParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
-
-	result, err := srv.PayeeAccountHistory(context.Background(), paramsJSON)
+	result, err := srv.PayeeAccountHistory(context.Background(), params)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/internal/server/protocol_server.go
+++ b/internal/server/protocol_server.go
@@ -26,11 +26,18 @@ func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSy
 	if len(symbols) == 0 {
 		return nil, nil
 	}
+	if !s.clientCapabilities.supportsHierarchicalDocumentSymbols {
+		return protocol.SymbolInformationSlice(flattenDocumentSymbols(params.TextDocument.URI, symbols)), nil
+	}
 	return protocol.DocumentSymbolSlice(symbols), nil
 }
 
 func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (protocol.PrepareRenameResult, error) {
 	return s.prepareRename(ctx, params)
+}
+
+func (s *Server) Formatting(ctx context.Context, params *protocol.DocumentFormattingParams) ([]protocol.TextEdit, error) {
+	return s.Format(ctx, params)
 }
 
 func (s *Server) RangeFormatting(ctx context.Context, params *protocol.DocumentRangeFormattingParams) ([]protocol.TextEdit, error) {

--- a/internal/server/protocol_server.go
+++ b/internal/server/protocol_server.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"go.lsp.dev/protocol"
+)
+
+var _ protocol.Server = (*Server)(nil)
+
+func (s *Server) Completion(ctx context.Context, params *protocol.CompletionParams) (protocol.CompletionResult, error) {
+	return s.completion(ctx, params)
+}
+
+func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionParams) (protocol.DefinitionResult, error) {
+	locations, err := s.definition(ctx, params)
+	if err != nil || len(locations) == 0 {
+		return nil, err
+	}
+	return protocol.LocationSlice(locations), nil
+}
+
+func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) (protocol.DocumentSymbolResult, error) {
+	symbols, err := s.documentSymbols(ctx, params)
+	if err != nil || len(symbols) == 0 {
+		return nil, err
+	}
+	return protocol.DocumentSymbolSlice(symbols), nil
+}
+
+func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (protocol.PrepareRenameResult, error) {
+	return s.prepareRename(ctx, params)
+}
+
+func (s *Server) RangeFormatting(ctx context.Context, params *protocol.DocumentRangeFormattingParams) ([]protocol.TextEdit, error) {
+	return s.rangeFormatting(ctx, params)
+}
+
+func (s *Server) Symbols(ctx context.Context, params *protocol.WorkspaceSymbolParams) (protocol.WorkspaceSymbolResult, error) {
+	symbols, err := s.workspaceSymbols(ctx, params)
+	if err != nil || len(symbols) == 0 {
+		return nil, err
+	}
+	return protocol.SymbolInformationSlice(symbols), nil
+}
+
+func (s *Server) Request(ctx context.Context, method string, params any) (any, error) {
+	if method != "hledger/payeeAccountHistory" {
+		return s.UnimplementedServer.Request(ctx, method, params)
+	}
+
+	raw, ok := params.(protocol.LSPAny)
+	if !ok {
+		return nil, fmt.Errorf("hledger/payeeAccountHistory params type = %T, want protocol.LSPAny", params)
+	}
+
+	var decoded PayeeAccountHistoryParams
+	if err := protocol.Unmarshal(raw, &decoded); err != nil {
+		return nil, err
+	}
+	return s.PayeeAccountHistory(ctx, &decoded)
+}
+
+func (s *Server) rangeFormatting(ctx context.Context, params *protocol.DocumentRangeFormattingParams) ([]protocol.TextEdit, error) {
+	return s.RangeFormat(ctx, params)
+}
+
+func (s *Server) workspaceSymbols(ctx context.Context, params *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
+	return s.WorkspaceSymbol(ctx, params)
+}

--- a/internal/server/protocol_server.go
+++ b/internal/server/protocol_server.go
@@ -22,9 +22,9 @@ func (s *Server) Definition(ctx context.Context, params *protocol.DefinitionPara
 }
 
 func (s *Server) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) (protocol.DocumentSymbolResult, error) {
-	symbols, err := s.documentSymbols(ctx, params)
-	if err != nil || len(symbols) == 0 {
-		return nil, err
+	symbols := s.documentSymbols(ctx, params)
+	if len(symbols) == 0 {
+		return nil, nil
 	}
 	return protocol.DocumentSymbolSlice(symbols), nil
 }

--- a/internal/server/protocol_server_test.go
+++ b/internal/server/protocol_server_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+func TestServer_Request_PayeeAccountHistoryUsesTypedDecode(t *testing.T) {
+	srv := NewServer()
+	srv.documents.Store(uri.URI("file:///payee-history.journal"), `2024-01-15 lunch
+    expenses:food  $10.00
+    assets:cash`)
+
+	result, err := srv.Request(context.Background(), "hledger/payeeAccountHistory", protocol.LSPAny(`{"textDocument":{"uri":"file:///payee-history.journal"}}`))
+	require.NoError(t, err)
+
+	history, ok := result.(*PayeeAccountHistoryResult)
+	require.True(t, ok)
+	assert.Contains(t, history.PayeeAccounts, "lunch")
+}
+
+func TestServer_Request_InvalidPayeeAccountHistoryParams(t *testing.T) {
+	srv := NewServer()
+
+	result, err := srv.Request(context.Background(), "hledger/payeeAccountHistory", protocol.LSPAny(`{invalid`))
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestServer_Request_UnknownMethodFallsBackToUnimplemented(t *testing.T) {
+	srv := NewServer()
+
+	result, err := srv.Request(context.Background(), "hledger/unknownMethod", protocol.LSPAny(`{}`))
+	var rpcErr *jsonrpc2.Error
+	require.ErrorAs(t, err, &rpcErr)
+	require.Nil(t, result)
+	assert.Equal(t, jsonrpc2.Code(protocol.ErrorCodesMethodNotFound), rpcErr.Code)
+}
+
+func TestServer_ProtocolInterfaceAssertion(t *testing.T) {
+	var _ protocol.Server = (*Server)(nil)
+}

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -9,7 +9,7 @@ import (
 	"go.lsp.dev/uri"
 )
 
-func (s *Server) PrepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (*protocol.Range, error) {
+func (s *Server) prepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (protocol.PrepareRenameResult, error) {
 	doc, ok := s.getJournalDoc(params.TextDocument.URI)
 	if !ok {
 		return nil, nil

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -9,7 +9,7 @@ import (
 	"go.lsp.dev/uri"
 )
 
-func (s *Server) prepareRename(ctx context.Context, params *protocol.PrepareRenameParams) (protocol.PrepareRenameResult, error) {
+func (s *Server) prepareRename(_ context.Context, params *protocol.PrepareRenameParams) (protocol.PrepareRenameResult, error) {
 	doc, ok := s.getJournalDoc(params.TextDocument.URI)
 	if !ok {
 		return nil, nil

--- a/internal/server/rename_test.go
+++ b/internal/server/rename_test.go
@@ -26,12 +26,15 @@ func TestPrepareRename_Account(t *testing.T) {
 		},
 	}
 
-	result, err := srv.PrepareRename(context.Background(), params)
+	result, err := srv.prepareRename(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	assert.Equal(t, uint32(1), result.Start.Line)
-	assert.Equal(t, uint32(4), result.Start.Character)
+	renameRange, ok := result.(*protocol.Range)
+	require.True(t, ok)
+
+	assert.Equal(t, uint32(1), renameRange.Start.Line)
+	assert.Equal(t, uint32(4), renameRange.Start.Character)
 }
 
 func TestPrepareRename_InvalidPosition(t *testing.T) {
@@ -50,7 +53,7 @@ func TestPrepareRename_InvalidPosition(t *testing.T) {
 		},
 	}
 
-	result, err := srv.PrepareRename(context.Background(), params)
+	result, err := srv.prepareRename(context.Background(), params)
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }

--- a/internal/server/rules_guard_test.go
+++ b/internal/server/rules_guard_test.go
@@ -37,7 +37,7 @@ func TestRulesFileGuards_Definition(t *testing.T) {
 	srv := NewServer()
 	srv.documents.Store(rulesFileURI, journalLikeContent)
 
-	result, err := srv.Definition(context.Background(), &protocol.DefinitionParams{
+	result, err := srv.definition(context.Background(), &protocol.DefinitionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: rulesFileURI},
 			Position:     hoverPos,
@@ -66,7 +66,7 @@ func TestRulesFileGuards_PrepareRename(t *testing.T) {
 	srv := NewServer()
 	srv.documents.Store(rulesFileURI, journalLikeContent)
 
-	result, err := srv.PrepareRename(context.Background(), &protocol.PrepareRenameParams{
+	result, err := srv.prepareRename(context.Background(), &protocol.PrepareRenameParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: rulesFileURI},
 			Position:     hoverPos,

--- a/internal/server/rules_include_completion_test.go
+++ b/internal/server/rules_include_completion_test.go
@@ -41,7 +41,7 @@ func TestCompletion_RulesIncludedFields(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -89,7 +89,7 @@ func TestCompletion_RulesIncludedFields_InvalidationAfterDidChange(t *testing.T)
 	}
 
 	// First completion populates the loader cache with the v1 common.rules.
-	first, err := srv.Completion(context.Background(), params)
+	first, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	firstLabels := extractLabels(first.Items)
 	assert.Contains(t, firstLabels, "%date", "first completion should see %%date from v1")
@@ -108,7 +108,7 @@ func TestCompletion_RulesIncludedFields_InvalidationAfterDidChange(t *testing.T)
 		},
 	}))
 
-	second, err := srv.Completion(context.Background(), params)
+	second, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	secondLabels := extractLabels(second.Items)
 	assert.Contains(t, secondLabels, "%payee",
@@ -144,7 +144,7 @@ func TestCompletion_RulesIncludedFields_EditorContentPreferred(t *testing.T) {
 		},
 	}
 
-	result, err := srv.Completion(context.Background(), params)
+	result, err := srv.completion(context.Background(), params)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,9 @@ type diagEntry struct {
 }
 
 type Server struct {
+	protocol.UnimplementedServer
+
+	version               string
 	client                protocol.Client
 	documents             sync.Map
 	analyzer              *analyzer.Analyzer
@@ -63,7 +66,12 @@ type Server struct {
 }
 
 func NewServer() *Server {
+	return NewServerWithVersion("dev")
+}
+
+func NewServerWithVersion(version string) *Server {
 	srv := &Server{
+		version:      version,
 		analyzer:     analyzer.New(),
 		loader:       include.NewLoader(),
 		rulesLoader:  rules.NewLoader(),
@@ -106,6 +114,10 @@ func (s *Server) StoreDocument(uri uri.URI, content string) {
 }
 
 func (s *Server) Initialize(ctx context.Context, params *protocol.InitializeParams) (*protocol.InitializeResult, error) {
+	if client, ok := protocol.ClientFromContext(ctx); ok {
+		s.SetClient(client)
+	}
+
 	if params != nil && params.Capabilities.Workspace != nil {
 		if configuration := params.Capabilities.Workspace.Configuration; configuration != nil {
 			s.supportsConfiguration = *configuration

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	workspace             *workspace.Workspace
 	settings              serverSettings
 	settingsMu            sync.RWMutex
+	clientCapabilities    clientCapabilities
 	supportsConfiguration bool
 	payeeTemplatesCache   sync.Map // map[uri.URI]map[string][]analyzer.PostingTemplate
 	alignmentCache        sync.Map // map[uri.URI]int
@@ -118,12 +119,9 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		s.SetClient(client)
 	}
 
-	if params != nil && params.Capabilities.Workspace != nil {
-		if configuration := params.Capabilities.Workspace.Configuration; configuration != nil {
-			s.supportsConfiguration = *configuration
-		}
-	}
 	if params != nil {
+		s.clientCapabilities = newClientCapabilities(params.Capabilities)
+		s.supportsConfiguration = s.clientCapabilities.supportsConfiguration
 		settings := parseSettingsFromLSPAny(s.getSettings(), params.InitializationOptions)
 		s.setSettings(settings)
 
@@ -161,9 +159,10 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		SelectionRangeProvider:    protocol.Boolean(true),
 		DefinitionProvider:        protocol.Boolean(true),
 		ReferencesProvider:        protocol.Boolean(true),
-		RenameProvider: &protocol.RenameOptions{
-			PrepareProvider: boolPtr(true),
-		},
+		RenameProvider:            protocol.Boolean(true),
+	}
+	if s.clientCapabilities.supportsRenamePrepare {
+		caps.RenameProvider = &protocol.RenameOptions{PrepareProvider: boolPtr(true)}
 	}
 
 	if settings.Features.Completion {
@@ -200,11 +199,14 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		caps.WorkspaceSymbolProvider = protocol.Boolean(true)
 	}
 	if settings.Features.CodeActions {
-		caps.CodeActionProvider = &protocol.CodeActionOptions{
-			CodeActionKinds: []protocol.CodeActionKind{
-				protocol.CodeActionKindQuickFix,
-				"source.hledger",
-			},
+		caps.CodeActionProvider = protocol.Boolean(true)
+		if s.clientCapabilities.supportsCodeActionLiterals {
+			caps.CodeActionProvider = &protocol.CodeActionOptions{
+				CodeActionKinds: []protocol.CodeActionKind{
+					protocol.CodeActionKindQuickFix,
+					"source.hledger",
+				},
+			}
 		}
 	}
 
@@ -225,20 +227,14 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		caps.ExecuteCommandProvider = protocol.ExecuteCommandOptions{Commands: commands}
 	}
 	if settings.Features.InlineCompletion {
-		experimental, err := protocol.Marshal(map[string]any{
-			"inlineCompletionProvider": true,
-		})
-		if err != nil {
-			return nil, err
-		}
-		caps.Experimental = protocol.LSPAny(experimental)
+		caps.InlineCompletionProvider = &protocol.InlineCompletionOptions{}
 	}
 
 	return &protocol.InitializeResult{
 		Capabilities: caps,
 		ServerInfo: protocol.ServerInfo{
 			Name:    "hledger-lsp",
-			Version: protocol.NewOptional("0.1.0"),
+			Version: protocol.NewOptional(s.version),
 		},
 	}, nil
 }
@@ -253,7 +249,9 @@ func (s *Server) Initialized(_ context.Context, _ *protocol.InitializedParams) e
 		}
 	}
 	go s.refreshConfiguration(context.Background())
-	go s.registerFileWatchers()
+	if s.clientCapabilities.supportsDynamicFileWatchers {
+		go s.registerFileWatchers()
+	}
 	return nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -118,6 +118,59 @@ func TestServer_RegisterFileWatchers_IncludesPricesPattern(t *testing.T) {
 	assert.True(t, gotPricesPattern, "expected .prices watcher pattern to be registered")
 }
 
+func TestServer_Initialized_MinimalClientDoesNotRegisterFileWatchers(t *testing.T) {
+	srv := NewServer()
+	client := &mockClient{}
+	srv.SetClient(client)
+
+	_, err := srv.Initialize(context.Background(), &protocol.InitializeParams{})
+	require.NoError(t, err)
+	require.NoError(t, srv.Initialized(context.Background(), &protocol.InitializedParams{}))
+
+	assert.Never(t, func() bool {
+		return len(client.getRegistrations()) > 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestServer_Initialized_DynamicFileWatcherClientRegistersExistingPatternsOnce(t *testing.T) {
+	trueValue := true
+	srv := NewServer()
+	client := &mockClient{}
+	srv.SetClient(client)
+
+	_, err := srv.Initialize(context.Background(), &protocol.InitializeParams{
+		Capabilities: protocol.ClientCapabilities{
+			Workspace: &protocol.WorkspaceClientCapabilities{
+				DidChangeWatchedFiles: &protocol.DidChangeWatchedFilesClientCapabilities{
+					DynamicRegistration: &trueValue,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, srv.Initialized(context.Background(), &protocol.InitializedParams{}))
+
+	require.Eventually(t, func() bool {
+		return len(client.getRegistrations()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	registrations := client.getRegistrations()
+	require.Len(t, registrations, 1)
+	assert.Equal(t, "workspace/didChangeWatchedFiles", registrations[0].Method)
+
+	watchedOptions, err := unmarshalLSPAny[protocol.DidChangeWatchedFilesRegistrationOptions](registrations[0].RegisterOptions)
+	require.NoError(t, err)
+
+	assert.Equal(t, []protocol.FileSystemWatcher{
+		{GlobPattern: protocol.Pattern("**/*.journal")},
+		{GlobPattern: protocol.Pattern("**/*.hledger")},
+		{GlobPattern: protocol.Pattern("**/*.j")},
+		{GlobPattern: protocol.Pattern("**/*.ledger")},
+		{GlobPattern: protocol.Pattern("**/*.prices")},
+		{GlobPattern: protocol.Pattern("**/*.rules")},
+	}, watchedOptions.Watchers)
+}
+
 // TestServer_DidChangeConfiguration_NonBlocking verifies that DidChangeConfiguration
 // returns immediately without blocking. Uses same timing assumptions as above.
 func TestServer_DidChangeConfiguration_NonBlocking(t *testing.T) {
@@ -180,7 +233,16 @@ func TestServer_Initialize(t *testing.T) {
 
 	require.NotNil(t, result.ServerInfo)
 	assert.Equal(t, "hledger-lsp", result.ServerInfo.Name)
-	assert.Equal(t, "0.1.0", optionalString(result.ServerInfo.Version))
+	assert.Equal(t, "dev", optionalString(result.ServerInfo.Version))
+}
+
+func TestNewServerWithVersion_InitializeReportsVersion(t *testing.T) {
+	srv := NewServerWithVersion("test-version")
+
+	result, err := srv.Initialize(context.Background(), &protocol.InitializeParams{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "test-version", optionalString(result.ServerInfo.Version))
 }
 
 func TestServer_Initialized(t *testing.T) {

--- a/internal/server/symbol.go
+++ b/internal/server/symbol.go
@@ -13,21 +13,21 @@ import (
 )
 
 func (s *Server) documentSymbols(
-	ctx context.Context,
+	_ context.Context,
 	params *protocol.DocumentSymbolParams,
-) ([]protocol.DocumentSymbol, error) {
+) []protocol.DocumentSymbol {
 	doc, ok := s.GetDocument(params.TextDocument.URI)
 	if !ok {
-		return nil, nil
+		return nil
 	}
 
 	if filetype.IsRules(string(params.TextDocument.URI)) {
-		return rulesDocumentSymbols(doc), nil
+		return rulesDocumentSymbols(doc)
 	}
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	if journal == nil {
-		return nil, nil
+		return nil
 	}
 
 	symbols := make([]protocol.DocumentSymbol, 0, len(journal.Transactions)+len(journal.Directives)+len(journal.Includes))
@@ -42,7 +42,7 @@ func (s *Server) documentSymbols(
 		symbols = append(symbols, includeToSymbol(inc))
 	}
 
-	return symbols, nil
+	return symbols
 }
 
 func groupTransactionsByMonth(transactions []ast.Transaction) []protocol.DocumentSymbol {

--- a/internal/server/symbol.go
+++ b/internal/server/symbol.go
@@ -12,10 +12,10 @@ import (
 	"github.com/juev/hledger-lsp/internal/rules"
 )
 
-func (s *Server) DocumentSymbol(
+func (s *Server) documentSymbols(
 	ctx context.Context,
 	params *protocol.DocumentSymbolParams,
-) ([]any, error) {
+) ([]protocol.DocumentSymbol, error) {
 	doc, ok := s.GetDocument(params.TextDocument.URI)
 	if !ok {
 		return nil, nil
@@ -27,10 +27,10 @@ func (s *Server) DocumentSymbol(
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	if journal == nil {
-		return []any{}, nil
+		return nil, nil
 	}
 
-	var symbols []any
+	symbols := make([]protocol.DocumentSymbol, 0, len(journal.Transactions)+len(journal.Directives)+len(journal.Includes))
 
 	symbols = append(symbols, groupTransactionsByMonth(journal.Transactions)...)
 
@@ -45,7 +45,7 @@ func (s *Server) DocumentSymbol(
 	return symbols, nil
 }
 
-func groupTransactionsByMonth(transactions []ast.Transaction) []any {
+func groupTransactionsByMonth(transactions []ast.Transaction) []protocol.DocumentSymbol {
 	if len(transactions) == 0 {
 		return nil
 	}
@@ -74,7 +74,7 @@ func groupTransactionsByMonth(transactions []ast.Transaction) []any {
 
 	sort.Strings(order)
 
-	result := make([]any, 0, len(order))
+	result := make([]protocol.DocumentSymbol, 0, len(order))
 	for _, key := range order {
 		g := groups[key]
 		rng := *astRangeToProtocol(ast.Range{
@@ -154,10 +154,10 @@ func directiveToSymbol(dir ast.Directive) protocol.DocumentSymbol {
 	}
 }
 
-func rulesDocumentSymbols(doc string) []any {
+func rulesDocumentSymbols(doc string) []protocol.DocumentSymbol {
 	rf, _ := rules.Parse(doc)
 	syms := rules.Symbols(rf)
-	result := make([]any, 0, len(syms))
+	result := make([]protocol.DocumentSymbol, 0, len(syms))
 	for _, sym := range syms {
 		rng := *astRangeToProtocol(sym.Range)
 		result = append(result, protocol.DocumentSymbol{

--- a/internal/server/symbol.go
+++ b/internal/server/symbol.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/filetype"
@@ -168,4 +169,28 @@ func rulesDocumentSymbols(doc string) []protocol.DocumentSymbol {
 		})
 	}
 	return result
+}
+
+func flattenDocumentSymbols(documentURI uri.URI, symbols []protocol.DocumentSymbol) []protocol.SymbolInformation {
+	result := make([]protocol.SymbolInformation, 0, len(symbols))
+	for _, symbol := range symbols {
+		flattenDocumentSymbol(documentURI, symbol, nil, &result)
+	}
+	return result
+}
+
+func flattenDocumentSymbol(documentURI uri.URI, symbol protocol.DocumentSymbol, containerName *string, result *[]protocol.SymbolInformation) {
+	*result = append(*result, protocol.SymbolInformation{
+		BaseSymbolInformation: protocol.BaseSymbolInformation{
+			Name:          symbol.Name,
+			Kind:          symbol.Kind,
+			Tags:          symbol.Tags,
+			ContainerName: containerName,
+		},
+		Location: protocol.Location{URI: documentURI, Range: symbol.Range},
+	})
+
+	for _, child := range symbol.Children {
+		flattenDocumentSymbol(documentURI, child, &symbol.Name, result)
+	}
 }

--- a/internal/server/symbol_test.go
+++ b/internal/server/symbol_test.go
@@ -20,7 +20,7 @@ func TestDocumentSymbol_Empty(t *testing.T) {
 		},
 	}
 
-	result, err := srv.DocumentSymbol(context.Background(), params)
+	result, err := srv.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -34,7 +34,7 @@ func TestDocumentSymbol_DocumentNotFound(t *testing.T) {
 		},
 	}
 
-	result, err := srv.DocumentSymbol(context.Background(), params)
+	result, err := srv.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }
@@ -57,7 +57,7 @@ func TestDocumentSymbol_Transactions(t *testing.T) {
 		},
 	}
 
-	result, err := srv.DocumentSymbol(context.Background(), params)
+	result, err := srv.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 1, "transactions grouped by month")
 
@@ -90,7 +90,7 @@ account expenses:food`
 		},
 	}
 
-	result, err := srv.DocumentSymbol(context.Background(), params)
+	result, err := srv.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 
@@ -119,7 +119,7 @@ commodity EUR`
 		},
 	}
 
-	result, err := srv.DocumentSymbol(context.Background(), params)
+	result, err := srv.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 
@@ -146,7 +146,7 @@ include /path/to/other.journal`
 		},
 	}
 
-	result, err := srv.DocumentSymbol(context.Background(), params)
+	result, err := srv.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 
@@ -179,7 +179,7 @@ include ./other.journal`
 		},
 	}
 
-	result, err := srv.DocumentSymbol(context.Background(), params)
+	result, err := srv.documentSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.Len(t, result, 4, "month group + account + commodity + include")
 
@@ -204,15 +204,9 @@ include ./other.journal`
 	}
 }
 
-func toDocumentSymbols(t *testing.T, result []any) []protocol.DocumentSymbol {
+func toDocumentSymbols(t *testing.T, result []protocol.DocumentSymbol) []protocol.DocumentSymbol {
 	t.Helper()
-	symbols := make([]protocol.DocumentSymbol, 0, len(result))
-	for _, item := range result {
-		sym, ok := item.(protocol.DocumentSymbol)
-		require.True(t, ok, "expected protocol.DocumentSymbol")
-		symbols = append(symbols, sym)
-	}
-	return symbols
+	return result
 }
 
 func TestDocumentSymbol_RangeEndIsSet(t *testing.T) {
@@ -253,7 +247,7 @@ func TestDocumentSymbol_RangeEndIsSet(t *testing.T) {
 				},
 			}
 
-			result, err := srv.DocumentSymbol(context.Background(), params)
+			result, err := srv.documentSymbols(context.Background(), params)
 			require.NoError(t, err)
 			require.NotEmpty(t, result, "expected at least one symbol")
 

--- a/internal/server/symbol_test.go
+++ b/internal/server/symbol_test.go
@@ -20,8 +20,7 @@ func TestDocumentSymbol_Empty(t *testing.T) {
 		},
 	}
 
-	result, err := srv.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	result := srv.documentSymbols(context.Background(), params)
 	assert.Empty(t, result)
 }
 
@@ -34,8 +33,7 @@ func TestDocumentSymbol_DocumentNotFound(t *testing.T) {
 		},
 	}
 
-	result, err := srv.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	result := srv.documentSymbols(context.Background(), params)
 	assert.Nil(t, result)
 }
 
@@ -57,8 +55,7 @@ func TestDocumentSymbol_Transactions(t *testing.T) {
 		},
 	}
 
-	result, err := srv.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	result := srv.documentSymbols(context.Background(), params)
 	require.Len(t, result, 1, "transactions grouped by month")
 
 	symbols := toDocumentSymbols(t, result)
@@ -90,8 +87,7 @@ account expenses:food`
 		},
 	}
 
-	result, err := srv.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	result := srv.documentSymbols(context.Background(), params)
 	require.Len(t, result, 2)
 
 	symbols := toDocumentSymbols(t, result)
@@ -119,8 +115,7 @@ commodity EUR`
 		},
 	}
 
-	result, err := srv.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	result := srv.documentSymbols(context.Background(), params)
 	require.Len(t, result, 2)
 
 	symbols := toDocumentSymbols(t, result)
@@ -146,8 +141,7 @@ include /path/to/other.journal`
 		},
 	}
 
-	result, err := srv.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	result := srv.documentSymbols(context.Background(), params)
 	require.Len(t, result, 2)
 
 	symbols := toDocumentSymbols(t, result)
@@ -179,8 +173,7 @@ include ./other.journal`
 		},
 	}
 
-	result, err := srv.documentSymbols(context.Background(), params)
-	require.NoError(t, err)
+	result := srv.documentSymbols(context.Background(), params)
 	require.Len(t, result, 4, "month group + account + commodity + include")
 
 	symbols := toDocumentSymbols(t, result)
@@ -247,8 +240,7 @@ func TestDocumentSymbol_RangeEndIsSet(t *testing.T) {
 				},
 			}
 
-			result, err := srv.documentSymbols(context.Background(), params)
-			require.NoError(t, err)
+			result := srv.documentSymbols(context.Background(), params)
 			require.NotEmpty(t, result, "expected at least one symbol")
 
 			symbols := toDocumentSymbols(t, result)

--- a/internal/server/symbol_test.go
+++ b/internal/server/symbol_test.go
@@ -253,3 +253,62 @@ func TestDocumentSymbol_RangeEndIsSet(t *testing.T) {
 		})
 	}
 }
+
+func TestDocumentSymbol_ProtocolResultMatchesClientHierarchySupport(t *testing.T) {
+	const documentURI = uri.URI("file:///test.journal")
+	params := &protocol.DocumentSymbolParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: documentURI},
+	}
+
+	newServerWithDocument := func() *Server {
+		srv := NewServer()
+		srv.documents.Store(documentURI, `2024-01-15 grocery
+    expenses:food  $50
+    assets:cash`)
+		return srv
+	}
+
+	t.Run("hierarchical client", func(t *testing.T) {
+		srv := newServerWithDocument()
+		srv.clientCapabilities.supportsHierarchicalDocumentSymbols = true
+
+		result, err := srv.DocumentSymbol(context.Background(), params)
+		require.NoError(t, err)
+		symbols, ok := result.(protocol.DocumentSymbolSlice)
+		require.True(t, ok)
+		require.Len(t, symbols, 1)
+		require.Len(t, symbols[0].Children, 1)
+	})
+
+	t.Run("minimal client", func(t *testing.T) {
+		srv := newServerWithDocument()
+		hierarchical := srv.documentSymbols(context.Background(), params)
+		require.Len(t, hierarchical, 1)
+		require.Len(t, hierarchical[0].Children, 1)
+
+		result, err := srv.DocumentSymbol(context.Background(), params)
+		require.NoError(t, err)
+		symbols, ok := result.(protocol.SymbolInformationSlice)
+		require.True(t, ok)
+		require.Len(t, symbols, 2)
+		assert.Equal(t, documentURI, symbols[0].Location.URI)
+		assert.Equal(t, hierarchical[0].Range, symbols[0].Location.Range)
+		assert.Nil(t, symbols[0].ContainerName)
+		assert.Equal(t, "2024-01", *symbols[1].ContainerName)
+		assert.Equal(t, documentURI, symbols[1].Location.URI)
+		assert.Equal(t, hierarchical[0].Children[0].Range, symbols[1].Location.Range)
+	})
+}
+
+func TestFlattenDocumentSymbols_PreservesMetadata(t *testing.T) {
+	symbols := flattenDocumentSymbols("file:///test.journal", []protocol.DocumentSymbol{
+		{
+			Name: "account assets",
+			Kind: protocol.SymbolKindClass,
+			Tags: []protocol.SymbolTag{protocol.SymbolTagDeprecated},
+		},
+	})
+
+	require.Len(t, symbols, 1)
+	assert.Equal(t, []protocol.SymbolTag{protocol.SymbolTagDeprecated}, symbols[0].Tags)
+}

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -191,7 +191,7 @@ func (ts *testServer) completion(uri uri.URI, line, character uint32) (*protocol
 			Position:     protocol.Position{Line: line, Character: character},
 		},
 	}
-	return ts.Completion(context.Background(), params)
+	return ts.Server.completion(context.Background(), params)
 }
 
 func (ts *testServer) hover(uri uri.URI, line uint32) (*protocol.Hover, error) {
@@ -219,7 +219,7 @@ func (ts *testServer) definition(uri uri.URI, line, character uint32) ([]protoco
 			Position:     protocol.Position{Line: line, Character: character},
 		},
 	}
-	return ts.Definition(context.Background(), params)
+	return ts.Server.definition(context.Background(), params)
 }
 
 //nolint:unparam // test helper keeps the character explicit at call sites

--- a/internal/server/workspace_symbol_test.go
+++ b/internal/server/workspace_symbol_test.go
@@ -32,7 +32,7 @@ account assets:cash
 		Query: "expenses",
 	}
 
-	result, err := srv.WorkspaceSymbol(context.Background(), params)
+	result, err := srv.workspaceSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(result), 2)
 
@@ -61,7 +61,7 @@ commodity EUR
 		Query: "USD",
 	}
 
-	result, err := srv.WorkspaceSymbol(context.Background(), params)
+	result, err := srv.workspaceSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 
@@ -91,7 +91,7 @@ func TestWorkspaceSymbol_Payees(t *testing.T) {
 		Query: "grocery",
 	}
 
-	result, err := srv.WorkspaceSymbol(context.Background(), params)
+	result, err := srv.workspaceSymbols(context.Background(), params)
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 
@@ -120,7 +120,7 @@ func TestWorkspaceSymbol_EmptyQuery(t *testing.T) {
 		Query: "",
 	}
 
-	result, err := srv.WorkspaceSymbol(context.Background(), params)
+	result, err := srv.workspaceSymbols(context.Background(), params)
 	require.NoError(t, err)
 	assert.NotEmpty(t, result)
 }
@@ -138,7 +138,7 @@ func TestWorkspaceSymbol_NoMatches(t *testing.T) {
 		Query: "nonexistent_symbol_xyz",
 	}
 
-	result, err := srv.WorkspaceSymbol(context.Background(), params)
+	result, err := srv.workspaceSymbols(context.Background(), params)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -162,7 +162,7 @@ func TestWorkspaceSymbol_NonOpenIncludeTreeFile(t *testing.T) {
 		"child.journal": "account expenses:food\ncommodity EUR\n\n2024-02-01 Child Payee\n    expenses:food  10 EUR\n    assets:cash\n",
 	})
 
-	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "child"})
+	result, err := srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "child"})
 	require.NoError(t, err)
 
 	var names []string
@@ -171,12 +171,12 @@ func TestWorkspaceSymbol_NonOpenIncludeTreeFile(t *testing.T) {
 	}
 	assert.Contains(t, names, "Child Payee", "payee from non-open included file")
 
-	result, err = srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "expenses:food"})
+	result, err = srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "expenses:food"})
 	require.NoError(t, err)
 	require.NotEmpty(t, result, "account from non-open included file")
 	assert.Equal(t, protocol.SymbolKindClass, result[0].Kind)
 
-	result, err = srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "EUR"})
+	result, err = srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "EUR"})
 	require.NoError(t, err)
 	require.NotEmpty(t, result, "commodity from non-open included file")
 	assert.Equal(t, protocol.SymbolKindEnum, result[0].Kind)
@@ -188,7 +188,7 @@ func TestWorkspaceSymbol_DeduplicatesRepeatedIncludes(t *testing.T) {
 		"shared.journal": "account expenses:shared\n\n2024-03-01 Shared Payee\n    expenses:shared  $5\n    assets:cash\n",
 	})
 
-	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "Shared Payee"})
+	result, err := srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "Shared Payee"})
 	require.NoError(t, err)
 
 	count := 0
@@ -206,7 +206,7 @@ func TestWorkspaceSymbol_FallbackWithoutWorkspace(t *testing.T) {
 	uri := uri.URI("file:///test.journal")
 	srv.documents.Store(uri, content)
 
-	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "expenses"})
+	result, err := srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "expenses"})
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 	assert.Equal(t, "expenses:food", result[0].Name)
@@ -220,7 +220,7 @@ func TestWorkspaceSymbol_OpenFileOutsideTree(t *testing.T) {
 	outsideURI := uri.URI("file:///tmp/outside.journal")
 	srv.documents.Store(outsideURI, "account expenses:outside\n\n2024-01-01 Outside Payee\n    expenses:outside  $1\n    assets:x\n")
 
-	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "outside"})
+	result, err := srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "outside"})
 	require.NoError(t, err)
 
 	var names []string
@@ -237,12 +237,12 @@ func TestWorkspaceSymbol_NonOpenFile_CRLF_Unicode(t *testing.T) {
 		"child.journal": "account расходы:еда\r\n\r\n2024-01-01 Магазин\r\n    расходы:еда  100 RUB\r\n    assets:cash\r\n",
 	})
 
-	result, err := srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "расходы"})
+	result, err := srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "расходы"})
 	require.NoError(t, err)
 	require.NotEmpty(t, result, "CJK/Cyrillic account from non-open CRLF file")
 	assert.Equal(t, "расходы:еда", result[0].Name)
 
-	result, err = srv.WorkspaceSymbol(context.Background(), &protocol.WorkspaceSymbolParams{Query: "Магазин"})
+	result, err = srv.workspaceSymbols(context.Background(), &protocol.WorkspaceSymbolParams{Query: "Магазин"})
 	require.NoError(t, err)
 	require.NotEmpty(t, result, "Cyrillic payee from non-open CRLF file")
 }


### PR DESCRIPTION
## Summary

Align the server with the LSP 3.18 lifecycle and protocol v1 contracts.

- Enforce initialize, initialized, shutdown, and exit state transitions with the required JSON-RPC errors and process exit codes.
- Preserve notification ordering and request cancellation with lifecycle middleware and selective asynchronous dispatch.
- Let `internal/server.Server` implement `protocol.Server` directly, use native union result types, and return `MethodNotFound` for unsupported requests.
- Negotiate rename, code action, document symbol, markup, and dynamic file watcher behavior from client capabilities.
- Advertise inline completion through the standard capability and report the runtime server version.
- Keep command-only code actions compatible without introducing a custom apply-edit bridge.
- Add wire and unit coverage for lifecycle, retries, cancellation, ordering, capability negotiation, result arms, formatting, and fallback behavior.

## Verification

- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test -race ./...`
- `go test -race ./cmd/hledger-lsp -run '^TestLSPWire_DidChangeCompletesBeforeInlineCompletion$' -count=20`
- `git diff --check`

Closes #66
