### PR TITLE
feat(server): add account type hierarchy

### DIFF
--- a/internal/server/protocol_server.go
+++ b/internal/server/protocol_server.go
@@ -52,6 +52,18 @@ func (s *Server) Symbols(ctx context.Context, params *protocol.WorkspaceSymbolPa
 	return protocol.SymbolInformationSlice(symbols), nil
 }
 
+func (s *Server) PrepareTypeHierarchy(ctx context.Context, params *protocol.TypeHierarchyPrepareParams) ([]protocol.TypeHierarchyItem, error) {
+	return s.prepareTypeHierarchy(ctx, params)
+}
+
+func (s *Server) Supertypes(ctx context.Context, params *protocol.TypeHierarchySupertypesParams) ([]protocol.TypeHierarchyItem, error) {
+	return s.typeHierarchySupertypes(ctx, params)
+}
+
+func (s *Server) Subtypes(ctx context.Context, params *protocol.TypeHierarchySubtypesParams) ([]protocol.TypeHierarchyItem, error) {
+	return s.typeHierarchySubtypes(ctx, params)
+}
+
 func (s *Server) Request(ctx context.Context, method string, params any) (any, error) {
 	if method != "hledger/payeeAccountHistory" {
 		return s.UnimplementedServer.Request(ctx, method, params)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,6 +160,7 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 		DefinitionProvider:        protocol.Boolean(true),
 		ReferencesProvider:        protocol.Boolean(true),
 		RenameProvider:            protocol.Boolean(true),
+		TypeHierarchyProvider:     protocol.Boolean(true),
 	}
 	if s.clientCapabilities.supportsRenamePrepare {
 		caps.RenameProvider = &protocol.RenameOptions{PrepareProvider: boolPtr(true)}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -92,6 +92,13 @@ func TestServer_Initialized_NonBlocking(t *testing.T) {
 	}
 }
 
+func TestServer_Initialize_AdvertisesTypeHierarchy(t *testing.T) {
+	srv := NewServer()
+	result, err := srv.Initialize(context.Background(), &protocol.InitializeParams{})
+	require.NoError(t, err)
+	assert.Equal(t, protocol.Boolean(true), result.Capabilities.TypeHierarchyProvider)
+}
+
 func TestServer_RegisterFileWatchers_IncludesPricesPattern(t *testing.T) {
 	srv := NewServer()
 	srv.diagDebounce = 0

--- a/internal/server/type_hierarchy.go
+++ b/internal/server/type_hierarchy.go
@@ -1,0 +1,311 @@
+package server
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+
+	"github.com/juev/hledger-lsp/internal/ast"
+	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/lsputil"
+)
+
+type typeHierarchyData struct {
+	Account string  `json:"account"`
+	Origin  uri.URI `json:"origin"`
+}
+
+type typeHierarchyCandidate struct {
+	name        string
+	uri         uri.URI
+	rangeValue  protocol.Range
+	declaration bool
+}
+
+type typeHierarchyAccountIdentity struct {
+	name   string
+	offset int
+}
+
+func (s *Server) prepareTypeHierarchy(_ context.Context, params *protocol.TypeHierarchyPrepareParams) ([]protocol.TypeHierarchyItem, error) {
+	if params == nil {
+		return nil, nil
+	}
+	doc, ok := s.getJournalDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	doc = normalizeLineEndings(doc)
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
+	mapper := lsputil.NewPositionMapper(doc)
+	for _, account := range hierarchyAccounts(journal) {
+		itemRange := hierarchyRange(mapper, account)
+		if positionInProtocolRange(params.Position, itemRange) {
+			names := s.typeHierarchyPreparedNames(params.TextDocument.URI, account)
+			items := make([]protocol.TypeHierarchyItem, 0, len(names))
+			for _, name := range names {
+				candidate := typeHierarchyCandidate{name: name, uri: params.TextDocument.URI, rangeValue: itemRange}
+				items = append(items, s.typeHierarchyItem(candidate, params.TextDocument.URI))
+			}
+			return items, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *Server) typeHierarchyPreparedNames(docURI uri.URI, account ast.Account) []string {
+	names := map[string]struct{}{account.GetResolvedName(): {}}
+	if resolved := s.getWorkspaceResolved(docURI); resolved != nil && len(resolved.Occurrences) > 0 {
+		names = make(map[string]struct{})
+		path := uriToPath(docURI)
+		for _, occurrence := range resolved.Occurrences {
+			if occurrence.Path != path || occurrence.Journal == nil {
+				continue
+			}
+			for _, contextual := range hierarchyAccounts(occurrence.Journal) {
+				if contextual.Name == account.Name && contextual.Range.Start.Offset == account.Range.Start.Offset {
+					names[contextual.GetResolvedName()] = struct{}{}
+				}
+			}
+		}
+		if len(names) == 0 {
+			names[account.GetResolvedName()] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(names))
+	for name := range names {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (s *Server) typeHierarchySupertypes(_ context.Context, params *protocol.TypeHierarchySupertypesParams) ([]protocol.TypeHierarchyItem, error) {
+	if params == nil {
+		return nil, nil
+	}
+	data, ok := decodeTypeHierarchyData(params.Item.Data)
+	if !ok {
+		return nil, nil
+	}
+	parent, ok := hierarchyParent(data.Account)
+	if !ok {
+		return nil, nil
+	}
+	candidates := s.typeHierarchyCandidates(data.Origin)
+	if !hasHierarchyName(candidates, parent) {
+		return nil, nil
+	}
+	candidate := candidateForName(candidates, parent)
+	candidate.name = parent
+	return []protocol.TypeHierarchyItem{s.typeHierarchyItem(candidate, data.Origin)}, nil
+}
+
+func (s *Server) typeHierarchySubtypes(_ context.Context, params *protocol.TypeHierarchySubtypesParams) ([]protocol.TypeHierarchyItem, error) {
+	if params == nil {
+		return nil, nil
+	}
+	data, ok := decodeTypeHierarchyData(params.Item.Data)
+	if !ok {
+		return nil, nil
+	}
+	candidates := s.typeHierarchyCandidates(data.Origin)
+	children := make(map[string]struct{})
+	for _, candidate := range candidates {
+		if child, ok := hierarchyDirectChild(data.Account, candidate.name); ok {
+			children[child] = struct{}{}
+		}
+	}
+	if len(children) == 0 || !hasHierarchyName(candidates, data.Account) {
+		return nil, nil
+	}
+	names := make([]string, 0, len(children))
+	for name := range children {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	items := make([]protocol.TypeHierarchyItem, 0, len(names))
+	for _, name := range names {
+		candidate := candidateForName(candidates, name)
+		candidate.name = name
+		items = append(items, s.typeHierarchyItem(candidate, data.Origin))
+	}
+	return items, nil
+}
+
+func (s *Server) typeHierarchyCandidates(origin uri.URI) []typeHierarchyCandidate {
+	resolved := s.getWorkspaceResolved(origin)
+	var occurrences []include.JournalOccurrence
+	if resolved != nil && len(resolved.Occurrences) > 0 {
+		occurrences = resolved.Occurrences
+	} else if resolved != nil {
+		if resolved.Primary != nil {
+			occurrences = append(occurrences, include.JournalOccurrence{Path: uriToPath(origin), Journal: resolved.Primary})
+		}
+		for _, path := range resolved.FileOrder {
+			if journal := resolved.Files[path]; journal != nil {
+				occurrences = append(occurrences, include.JournalOccurrence{Path: path, Journal: journal})
+			}
+		}
+	} else if doc, ok := s.GetDocument(origin); ok {
+		journal, _ := s.cachedJournal(origin, normalizeLineEndings(doc))
+		occurrences = append(occurrences, include.JournalOccurrence{Path: uriToPath(origin), Journal: journal})
+	}
+
+	var candidates []typeHierarchyCandidate
+	mappers := make(map[uri.URI]*lsputil.PositionMapper)
+	for _, occurrence := range occurrences {
+		if occurrence.Journal == nil || occurrence.Path == "" {
+			continue
+		}
+		docURI := pathToURI(occurrence.Path)
+		mapper := mappers[docURI]
+		if mapper == nil {
+			content, ok := s.typeHierarchySource(docURI)
+			if !ok {
+				continue
+			}
+			mapper = lsputil.NewPositionMapper(content)
+			mappers[docURI] = mapper
+		}
+		declarations := hierarchyDeclarationSet(occurrence.Journal)
+		for _, account := range hierarchyAccounts(occurrence.Journal) {
+			name := account.GetResolvedName()
+			if name == "" {
+				continue
+			}
+			candidates = append(candidates, typeHierarchyCandidate{name: name, uri: docURI, rangeValue: hierarchyRange(mapper, account), declaration: declarations[hierarchyAccountIdentity(account)]})
+		}
+	}
+	return candidates
+}
+
+func (s *Server) typeHierarchySource(docURI uri.URI) (string, bool) {
+	if content, ok := s.GetDocument(docURI); ok {
+		return normalizeLineEndings(content), true
+	}
+	content, err := os.ReadFile(uriToPath(docURI))
+	if err != nil {
+		return "", false
+	}
+	return normalizeLineEndings(string(content)), true
+}
+
+func (s *Server) typeHierarchyItem(candidate typeHierarchyCandidate, origin uri.URI) protocol.TypeHierarchyItem {
+	data, _ := protocol.Marshal(typeHierarchyData{Account: candidate.name, Origin: origin})
+	return protocol.TypeHierarchyItem{Name: candidate.name, Kind: protocol.SymbolKindClass, URI: candidate.uri, Range: candidate.rangeValue, SelectionRange: candidate.rangeValue, Data: protocol.LSPAny(data)}
+}
+
+func hierarchyAccounts(journal *ast.Journal) []ast.Account {
+	if journal == nil {
+		return nil
+	}
+	accounts := make([]ast.Account, 0)
+	for _, directive := range journal.Directives {
+		if declaration, ok := directive.(ast.AccountDirective); ok {
+			accounts = append(accounts, declaration.Account)
+		}
+	}
+	appendPostings := func(postings []ast.Posting) {
+		for _, posting := range postings {
+			accounts = append(accounts, posting.Account)
+		}
+	}
+	for _, transaction := range journal.Transactions {
+		appendPostings(transaction.Postings)
+	}
+	for _, transaction := range journal.PeriodicTransactions {
+		appendPostings(transaction.Postings)
+	}
+	for _, rule := range journal.AutoPostingRules {
+		appendPostings(rule.Postings)
+	}
+	return accounts
+}
+
+func hierarchyDeclarationSet(journal *ast.Journal) map[typeHierarchyAccountIdentity]bool {
+	declarations := make(map[typeHierarchyAccountIdentity]bool)
+	for _, directive := range journal.Directives {
+		if declaration, ok := directive.(ast.AccountDirective); ok {
+			declarations[hierarchyAccountIdentity(declaration.Account)] = true
+		}
+	}
+	return declarations
+}
+
+func hierarchyAccountIdentity(account ast.Account) typeHierarchyAccountIdentity {
+	return typeHierarchyAccountIdentity{name: account.Name, offset: account.Range.Start.Offset}
+}
+
+func hierarchyRange(mapper *lsputil.PositionMapper, account ast.Account) protocol.Range {
+	start := account.Range.Start.Offset
+	return protocol.Range{Start: mapper.ByteToLSP(start), End: mapper.ByteToLSP(start + len(account.Name))}
+}
+
+func decodeTypeHierarchyData(raw protocol.LSPAny) (typeHierarchyData, bool) {
+	var data typeHierarchyData
+	if len(raw) == 0 || protocol.Unmarshal(raw, &data) != nil || data.Account == "" || data.Origin == "" {
+		return typeHierarchyData{}, false
+	}
+	return data, true
+}
+
+func hierarchyParent(name string) (string, bool) {
+	index := strings.LastIndex(name, ":")
+	if index <= 0 {
+		return "", false
+	}
+	return name[:index], true
+}
+
+func hierarchyDirectChild(parent, name string) (string, bool) {
+	prefix := parent + ":"
+	if !strings.HasPrefix(name, prefix) {
+		return "", false
+	}
+	part := strings.SplitN(strings.TrimPrefix(name, prefix), ":", 2)[0]
+	if part == "" {
+		return "", false
+	}
+	return prefix + part, true
+}
+
+func hasHierarchyName(candidates []typeHierarchyCandidate, name string) bool {
+	for _, candidate := range candidates {
+		if candidate.name == name || strings.HasPrefix(candidate.name, name+":") {
+			return true
+		}
+	}
+	return false
+}
+
+func candidateForName(candidates []typeHierarchyCandidate, name string) typeHierarchyCandidate {
+	matching := make([]typeHierarchyCandidate, 0)
+	for _, candidate := range candidates {
+		if candidate.name == name || strings.HasPrefix(candidate.name, name+":") {
+			matching = append(matching, candidate)
+		}
+	}
+	sort.SliceStable(matching, func(i, j int) bool {
+		iExact := matching[i].name == name
+		jExact := matching[j].name == name
+		if iExact != jExact {
+			return iExact
+		}
+		if matching[i].declaration != matching[j].declaration {
+			return matching[i].declaration
+		}
+		if matching[i].uri != matching[j].uri {
+			return matching[i].uri < matching[j].uri
+		}
+		if matching[i].rangeValue.Start.Line != matching[j].rangeValue.Start.Line {
+			return matching[i].rangeValue.Start.Line < matching[j].rangeValue.Start.Line
+		}
+		return matching[i].rangeValue.Start.Character < matching[j].rangeValue.Start.Character
+	})
+	return matching[0]
+}

--- a/internal/server/type_hierarchy_test.go
+++ b/internal/server/type_hierarchy_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+func TestTypeHierarchy_LocalDirectAndSyntheticNodes(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///hierarchy.journal")
+	srv.StoreDocument(docURI, "account expenses:food\n\n2024-01-01 lunch\n    expenses:food:restaurants  $10\n    expenses:food:groceries  $5\n    assets:cash\n")
+
+	prepared, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+			Position:     protocol.Position{Line: 3, Character: 18},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, prepared, 1)
+	assert.Equal(t, "expenses:food:restaurants", prepared[0].Name)
+
+	parents, err := srv.Supertypes(context.Background(), &protocol.TypeHierarchySupertypesParams{Item: prepared[0]})
+	require.NoError(t, err)
+	require.Len(t, parents, 1)
+	assert.Equal(t, "expenses:food", parents[0].Name)
+
+	children, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: parents[0]})
+	require.NoError(t, err)
+	require.Len(t, children, 2)
+	assert.Equal(t, []string{"expenses:food:groceries", "expenses:food:restaurants"}, []string{children[0].Name, children[1].Name})
+
+	rootData, err := protocol.Marshal(typeHierarchyData{Account: "expenses", Origin: docURI})
+	require.NoError(t, err)
+	rootParents, err := srv.Supertypes(context.Background(), &protocol.TypeHierarchySupertypesParams{Item: protocol.TypeHierarchyItem{Data: protocol.LSPAny(rootData)}})
+	require.NoError(t, err)
+	assert.Nil(t, rootParents)
+}
+
+func TestTypeHierarchy_PreparesAccountDeclarationWithCompleteRange(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///declaration.journal")
+	srv.StoreDocument(docURI, "account expenses:food\n")
+
+	prepared, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+			Position:     protocol.Position{Line: 0, Character: 10},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, prepared, 1)
+	assert.Equal(t, "expenses:food", prepared[0].Name)
+	assert.Equal(t, protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 8},
+		End:   protocol.Position{Line: 0, Character: 21},
+	}, prepared[0].Range)
+}
+
+func TestTypeHierarchy_RejectsMalformedDataAndNonAccountPosition(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///hierarchy.journal")
+	srv.StoreDocument(docURI, "2024-01-01 lunch\n    expenses:food  $10\n")
+
+	prepared, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{TextDocument: protocol.TextDocumentIdentifier{URI: docURI}, Position: protocol.Position{Line: 0, Character: 1}},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, prepared)
+
+	children, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: protocol.TypeHierarchyItem{Data: protocol.LSPAny([]byte(`{"account":1}`))}})
+	require.NoError(t, err)
+	assert.Nil(t, children)
+}
+
+func TestTypeHierarchy_UsesUTF16RangesAndNormalizesCRLF(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///utf16.journal")
+	srv.StoreDocument(docURI, "2024-01-01 😀\r\n    Расходы:🍜  $10\r\n")
+
+	prepared, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{TextDocument: protocol.TextDocumentIdentifier{URI: docURI}, Position: protocol.Position{Line: 1, Character: 12}},
+	})
+	require.NoError(t, err)
+	require.Len(t, prepared, 1)
+	assert.Equal(t, protocol.Position{Line: 1, Character: 4}, prepared[0].Range.Start)
+	assert.Equal(t, protocol.Position{Line: 1, Character: 14}, prepared[0].Range.End)
+	assert.Equal(t, prepared[0].Range, prepared[0].SelectionRange)
+
+	miss, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{TextDocument: protocol.TextDocumentIdentifier{URI: docURI}, Position: protocol.Position{Line: 1, Character: 14}},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, miss)
+}
+
+func TestTypeHierarchy_CombinesRootAndIncludedAccounts(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.journal")
+	childPath := filepath.Join(dir, "child.journal")
+	main := "include child.journal\n2024-01-01 root\n    expenses:root  $1\n    assets:cash\n"
+	require.NoError(t, os.WriteFile(mainPath, []byte(main), 0o644))
+	require.NoError(t, os.WriteFile(childPath, []byte("2024-01-01 child\n    expenses:child  $1\n    assets:cash\n"), 0o644))
+
+	srv := NewServer()
+	mainURI := uri.File(mainPath)
+	srv.StoreDocument(mainURI, main)
+	resolved, errs := srv.loader.Load(mainPath)
+	require.Empty(t, errs)
+	srv.resolved.Store(mainURI, resolved)
+
+	data, err := protocol.Marshal(typeHierarchyData{Account: "expenses", Origin: mainURI})
+	require.NoError(t, err)
+	children, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: protocol.TypeHierarchyItem{Data: protocol.LSPAny(data)}})
+	require.NoError(t, err)
+	require.Len(t, children, 2)
+	assert.Equal(t, []string{"expenses:child", "expenses:root"}, []string{children[0].Name, children[1].Name})
+}
+
+func TestTypeHierarchy_PreservesRepeatedIncludeContexts(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.journal")
+	childPath := filepath.Join(dir, "child.journal")
+	main := "apply account first\ninclude child.journal\nend apply account\napply account second\ninclude child.journal\nend apply account\n"
+	require.NoError(t, os.WriteFile(mainPath, []byte(main), 0o644))
+	require.NoError(t, os.WriteFile(childPath, []byte("2024-01-01 child\n    cash  $1\n    assets:y\n"), 0o644))
+
+	srv := NewServer()
+	mainURI := uri.File(mainPath)
+	srv.StoreDocument(mainURI, main)
+	resolved, errs := srv.loader.Load(mainPath)
+	require.Empty(t, errs)
+	srv.resolved.Store(mainURI, resolved)
+
+	firstData, err := protocol.Marshal(typeHierarchyData{Account: "first", Origin: mainURI})
+	require.NoError(t, err)
+	first, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: protocol.TypeHierarchyItem{Data: protocol.LSPAny(firstData)}})
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, []string{"first:assets", "first:cash"}, []string{first[0].Name, first[1].Name})
+
+	secondData, err := protocol.Marshal(typeHierarchyData{Account: "second", Origin: mainURI})
+	require.NoError(t, err)
+	second, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: protocol.TypeHierarchyItem{Data: protocol.LSPAny(secondData)}})
+	require.NoError(t, err)
+	require.Len(t, second, 2)
+	assert.Equal(t, []string{"second:assets", "second:cash"}, []string{second[0].Name, second[1].Name})
+}
+
+func TestTypeHierarchy_PrefersExactOccurrenceOverDescendantDeclaration(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///exact-anchor.journal")
+	srv.StoreDocument(docURI, "account expenses:food:restaurants\n\n2024-01-01 lunch\n    expenses:food  $10\n    assets:cash\n")
+
+	data, err := protocol.Marshal(typeHierarchyData{Account: "expenses:food", Origin: docURI})
+	require.NoError(t, err)
+	children, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: protocol.TypeHierarchyItem{Data: protocol.LSPAny(data)}})
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+
+	parent, err := srv.Supertypes(context.Background(), &protocol.TypeHierarchySupertypesParams{Item: children[0]})
+	require.NoError(t, err)
+	require.Len(t, parent, 1)
+	assert.Equal(t, protocol.Position{Line: 3, Character: 4}, parent[0].Range.Start)
+}
+
+func TestTypeHierarchy_PrepareIncludedAccountUsesAllOccurrenceContexts(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.journal")
+	childPath := filepath.Join(dir, "child.journal")
+	main := "apply account first\ninclude child.journal\nend apply account\napply account second\ninclude child.journal\nend apply account\n"
+	child := "2024-01-01 child\n    cash  $1\n    assets:y\n"
+	require.NoError(t, os.WriteFile(mainPath, []byte(main), 0o644))
+	require.NoError(t, os.WriteFile(childPath, []byte(child), 0o644))
+
+	srv := NewServer()
+	childURI := uri.File(childPath)
+	srv.StoreDocument(childURI, child)
+	resolved, errs := srv.loader.Load(mainPath)
+	require.Empty(t, errs)
+	srv.resolved.Store(childURI, resolved)
+
+	items, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{TextDocument: protocol.TextDocumentIdentifier{URI: childURI}, Position: protocol.Position{Line: 1, Character: 5}},
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, []string{"first:cash", "second:cash"}, []string{items[0].Name, items[1].Name})
+	for i, item := range items {
+		data, ok := decodeTypeHierarchyData(item.Data)
+		require.True(t, ok)
+		assert.Equal(t, childURI, data.Origin)
+		parents, err := srv.Supertypes(context.Background(), &protocol.TypeHierarchySupertypesParams{Item: item})
+		require.NoError(t, err)
+		require.Len(t, parents, 1)
+		assert.Equal(t, []string{"first", "second"}[i], parents[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary

Adds account hierarchy navigation through the standard LSP Type Hierarchy API. Users can navigate from `expenses:food:restaurants` to its parent account and list its direct children, including accounts from included files.

Closes #44

## Changes

- Register `typeHierarchyProvider` and add typed handlers for prepare, supertypes, and subtypes.
- Resolve direct parents and children, synthetic prefix nodes, and deterministic source anchors.
- Preserve include-tree context, including repeated includes under different `apply account` directives.
- Return correct UTF-16 ranges and handle malformed hierarchy data safely.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `golangci-lint run ./...`
- `git diff --check`

## Code references

- `internal/server/type_hierarchy.go` — hierarchy construction, include context, and source ranges.
- `internal/server/protocol_server.go` — LSP protocol adapters.
- `internal/server/server.go` — capability registration.
- `internal/server/type_hierarchy_test.go` — local and included accounts, repeated includes, CRLF, and UTF-16 cases.
