### PR TITLE
fix(server): preserve type hierarchy contexts

### DIFF
--- a/internal/server/type_hierarchy.go
+++ b/internal/server/type_hierarchy.go
@@ -15,8 +15,9 @@ import (
 )
 
 type typeHierarchyData struct {
-	Account string  `json:"account"`
-	Origin  uri.URI `json:"origin"`
+	Account  string  `json:"account"`
+	Origin   uri.URI `json:"origin"`
+	RootPath string  `json:"rootPath,omitempty"`
 }
 
 type typeHierarchyCandidate struct {
@@ -24,6 +25,11 @@ type typeHierarchyCandidate struct {
 	uri         uri.URI
 	rangeValue  protocol.Range
 	declaration bool
+}
+
+type typeHierarchyPreparedName struct {
+	name     string
+	rootPath string
 }
 
 type typeHierarchyAccountIdentity struct {
@@ -47,9 +53,9 @@ func (s *Server) prepareTypeHierarchy(_ context.Context, params *protocol.TypeHi
 		if positionInProtocolRange(params.Position, itemRange) {
 			names := s.typeHierarchyPreparedNames(params.TextDocument.URI, account)
 			items := make([]protocol.TypeHierarchyItem, 0, len(names))
-			for _, name := range names {
-				candidate := typeHierarchyCandidate{name: name, uri: params.TextDocument.URI, rangeValue: itemRange}
-				items = append(items, s.typeHierarchyItem(candidate, params.TextDocument.URI))
+			for _, prepared := range names {
+				candidate := typeHierarchyCandidate{name: prepared.name, uri: params.TextDocument.URI, rangeValue: itemRange}
+				items = append(items, s.typeHierarchyItem(candidate, params.TextDocument.URI, prepared.rootPath))
 			}
 			return items, nil
 		}
@@ -57,30 +63,42 @@ func (s *Server) prepareTypeHierarchy(_ context.Context, params *protocol.TypeHi
 	return nil, nil
 }
 
-func (s *Server) typeHierarchyPreparedNames(docURI uri.URI, account ast.Account) []string {
-	names := map[string]struct{}{account.GetResolvedName(): {}}
-	if resolved := s.getWorkspaceResolved(docURI); resolved != nil && len(resolved.Occurrences) > 0 {
-		names = make(map[string]struct{})
-		path := uriToPath(docURI)
-		for _, occurrence := range resolved.Occurrences {
+func (s *Server) typeHierarchyPreparedNames(docURI uri.URI, account ast.Account) []typeHierarchyPreparedName {
+	path := uriToPath(docURI)
+	resolvedTrees := s.typeHierarchyTrees(docURI)
+	if len(resolvedTrees) == 0 {
+		resolvedTrees = []typeHierarchyTree{{resolved: s.GetResolved(docURI)}}
+	}
+
+	names := make(map[typeHierarchyPreparedName]struct{})
+	for _, tree := range resolvedTrees {
+		if tree.resolved == nil || len(tree.resolved.Occurrences) == 0 {
+			continue
+		}
+		for _, occurrence := range tree.resolved.Occurrences {
 			if occurrence.Path != path || occurrence.Journal == nil {
 				continue
 			}
 			for _, contextual := range hierarchyAccounts(occurrence.Journal) {
 				if contextual.Name == account.Name && contextual.Range.Start.Offset == account.Range.Start.Offset {
-					names[contextual.GetResolvedName()] = struct{}{}
+					names[typeHierarchyPreparedName{name: contextual.GetResolvedName(), rootPath: tree.rootPath}] = struct{}{}
 				}
 			}
 		}
-		if len(names) == 0 {
-			names[account.GetResolvedName()] = struct{}{}
-		}
 	}
-	result := make([]string, 0, len(names))
+	if len(names) == 0 {
+		names[typeHierarchyPreparedName{name: account.GetResolvedName()}] = struct{}{}
+	}
+	result := make([]typeHierarchyPreparedName, 0, len(names))
 	for name := range names {
 		result = append(result, name)
 	}
-	sort.Strings(result)
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].name != result[j].name {
+			return result[i].name < result[j].name
+		}
+		return result[i].rootPath < result[j].rootPath
+	})
 	return result
 }
 
@@ -96,13 +114,13 @@ func (s *Server) typeHierarchySupertypes(_ context.Context, params *protocol.Typ
 	if !ok {
 		return nil, nil
 	}
-	candidates := s.typeHierarchyCandidates(data.Origin)
+	candidates := s.typeHierarchyCandidates(data.Origin, data.RootPath)
 	if !hasHierarchyName(candidates, parent) {
 		return nil, nil
 	}
 	candidate := candidateForName(candidates, parent)
 	candidate.name = parent
-	return []protocol.TypeHierarchyItem{s.typeHierarchyItem(candidate, data.Origin)}, nil
+	return []protocol.TypeHierarchyItem{s.typeHierarchyItem(candidate, data.Origin, data.RootPath)}, nil
 }
 
 func (s *Server) typeHierarchySubtypes(_ context.Context, params *protocol.TypeHierarchySubtypesParams) ([]protocol.TypeHierarchyItem, error) {
@@ -113,7 +131,7 @@ func (s *Server) typeHierarchySubtypes(_ context.Context, params *protocol.TypeH
 	if !ok {
 		return nil, nil
 	}
-	candidates := s.typeHierarchyCandidates(data.Origin)
+	candidates := s.typeHierarchyCandidates(data.Origin, data.RootPath)
 	children := make(map[string]struct{})
 	for _, candidate := range candidates {
 		if child, ok := hierarchyDirectChild(data.Account, candidate.name); ok {
@@ -132,13 +150,50 @@ func (s *Server) typeHierarchySubtypes(_ context.Context, params *protocol.TypeH
 	for _, name := range names {
 		candidate := candidateForName(candidates, name)
 		candidate.name = name
-		items = append(items, s.typeHierarchyItem(candidate, data.Origin))
+		items = append(items, s.typeHierarchyItem(candidate, data.Origin, data.RootPath))
 	}
 	return items, nil
 }
 
-func (s *Server) typeHierarchyCandidates(origin uri.URI) []typeHierarchyCandidate {
-	resolved := s.getWorkspaceResolved(origin)
+type typeHierarchyTree struct {
+	rootPath string
+	resolved *include.ResolvedJournal
+}
+
+func (s *Server) typeHierarchyTrees(origin uri.URI) []typeHierarchyTree {
+	if s.workspace == nil {
+		return nil
+	}
+	path := uriToPath(origin)
+	if path == "" {
+		return nil
+	}
+	trees := s.workspace.GetIncludeTreesForFile(path)
+	result := make([]typeHierarchyTree, 0, len(trees))
+	for _, tree := range trees {
+		result = append(result, typeHierarchyTree{rootPath: tree.RootPath, resolved: tree.Resolved})
+	}
+	return result
+}
+
+func (s *Server) typeHierarchyCandidates(origin uri.URI, rootPath string) []typeHierarchyCandidate {
+	var resolved *include.ResolvedJournal
+	if rootPath != "" {
+		for _, tree := range s.typeHierarchyTrees(origin) {
+			if tree.rootPath == rootPath {
+				resolved = tree.resolved
+				break
+			}
+		}
+		if resolved == nil {
+			return nil
+		}
+	} else {
+		resolved = s.getWorkspaceResolved(origin)
+	}
+	if resolved == nil {
+		resolved = s.GetResolved(origin)
+	}
 	var occurrences []include.JournalOccurrence
 	if resolved != nil && len(resolved.Occurrences) > 0 {
 		occurrences = resolved.Occurrences
@@ -159,10 +214,13 @@ func (s *Server) typeHierarchyCandidates(origin uri.URI) []typeHierarchyCandidat
 	var candidates []typeHierarchyCandidate
 	mappers := make(map[uri.URI]*lsputil.PositionMapper)
 	for _, occurrence := range occurrences {
-		if occurrence.Journal == nil || occurrence.Path == "" {
+		if occurrence.Journal == nil {
 			continue
 		}
-		docURI := pathToURI(occurrence.Path)
+		docURI := origin
+		if occurrence.Path != "" {
+			docURI = pathToURI(occurrence.Path)
+		}
 		mapper := mappers[docURI]
 		if mapper == nil {
 			content, ok := s.typeHierarchySource(docURI)
@@ -195,8 +253,8 @@ func (s *Server) typeHierarchySource(docURI uri.URI) (string, bool) {
 	return normalizeLineEndings(string(content)), true
 }
 
-func (s *Server) typeHierarchyItem(candidate typeHierarchyCandidate, origin uri.URI) protocol.TypeHierarchyItem {
-	data, _ := protocol.Marshal(typeHierarchyData{Account: candidate.name, Origin: origin})
+func (s *Server) typeHierarchyItem(candidate typeHierarchyCandidate, origin uri.URI, rootPath string) protocol.TypeHierarchyItem {
+	data, _ := protocol.Marshal(typeHierarchyData{Account: candidate.name, Origin: origin, RootPath: rootPath})
 	return protocol.TypeHierarchyItem{Name: candidate.name, Kind: protocol.SymbolKindClass, URI: candidate.uri, Range: candidate.rangeValue, SelectionRange: candidate.rangeValue, Data: protocol.LSPAny(data)}
 }
 

--- a/internal/server/type_hierarchy_test.go
+++ b/internal/server/type_hierarchy_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
+
+	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/workspace"
 )
 
 func TestTypeHierarchy_LocalDirectAndSyntheticNodes(t *testing.T) {
@@ -202,4 +205,86 @@ func TestTypeHierarchy_PrepareIncludedAccountUsesAllOccurrenceContexts(t *testin
 		require.Len(t, parents, 1)
 		assert.Equal(t, []string{"first", "second"}[i], parents[0].Name)
 	}
+}
+
+func TestTypeHierarchy_WorkspaceOwnersKeepApplyAccountContext(t *testing.T) {
+	dir := t.TempDir()
+	childPath := filepath.Join(dir, "child.journal")
+	firstRootPath := filepath.Join(dir, "a-root.journal")
+	secondRootPath := filepath.Join(dir, "b-root.journal")
+	child := "2024-01-01 child\n    cash  $1\n    assets:y\n"
+	require.NoError(t, os.WriteFile(childPath, []byte(child), 0o644))
+	require.NoError(t, os.WriteFile(firstRootPath, []byte("apply account first\ninclude child.journal\nend apply account\n"), 0o644))
+	require.NoError(t, os.WriteFile(secondRootPath, []byte("apply account second\ninclude child.journal\nend apply account\n"), 0o644))
+
+	srv := NewServer()
+	srv.loader = include.NewLoader()
+	srv.workspace = workspace.NewWorkspace(dir, srv.loader)
+	require.NoError(t, srv.workspace.Initialize())
+	childURI := uri.File(childPath)
+	srv.StoreDocument(childURI, child)
+
+	items, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{TextDocument: protocol.TextDocumentIdentifier{URI: childURI}, Position: protocol.Position{Line: 1, Character: 5}},
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, []string{"first:cash", "second:cash"}, []string{items[0].Name, items[1].Name})
+
+	for i, item := range items {
+		data, ok := decodeTypeHierarchyData(item.Data)
+		require.True(t, ok)
+		assert.Equal(t, []string{firstRootPath, secondRootPath}[i], data.RootPath)
+		parents, err := srv.Supertypes(context.Background(), &protocol.TypeHierarchySupertypesParams{Item: item})
+		require.NoError(t, err)
+		require.Len(t, parents, 1)
+		assert.Equal(t, []string{"first", "second"}[i], parents[0].Name)
+	}
+}
+
+func TestTypeHierarchy_RejectsUnknownWorkspaceRootPath(t *testing.T) {
+	dir := t.TempDir()
+	childPath := filepath.Join(dir, "child.journal")
+	rootPath := filepath.Join(dir, "root.journal")
+	child := "2024-01-01 child\n    cash  $1\n    assets:y\n"
+	require.NoError(t, os.WriteFile(childPath, []byte(child), 0o644))
+	require.NoError(t, os.WriteFile(rootPath, []byte("apply account first\ninclude child.journal\nend apply account\n"), 0o644))
+
+	srv := NewServer()
+	srv.loader = include.NewLoader()
+	srv.workspace = workspace.NewWorkspace(dir, srv.loader)
+	require.NoError(t, srv.workspace.Initialize())
+	childURI := uri.File(childPath)
+	srv.StoreDocument(childURI, child)
+
+	data, err := protocol.Marshal(typeHierarchyData{Account: "assets", Origin: childURI, RootPath: filepath.Join(dir, "missing.journal")})
+	require.NoError(t, err)
+	children, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: protocol.TypeHierarchyItem{Data: protocol.LSPAny(data)}})
+	require.NoError(t, err)
+	assert.Nil(t, children)
+}
+
+func TestTypeHierarchy_UntitledDocumentKeepsURIForFollowups(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("untitled:hledger")
+	srv.StoreDocument(docURI, "2024-01-01 lunch\n    expenses:food  $10\n    assets:cash\n")
+
+	items, err := srv.PrepareTypeHierarchy(context.Background(), &protocol.TypeHierarchyPrepareParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{TextDocument: protocol.TextDocumentIdentifier{URI: docURI}, Position: protocol.Position{Line: 1, Character: 12}},
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, docURI, items[0].URI)
+
+	parents, err := srv.Supertypes(context.Background(), &protocol.TypeHierarchySupertypesParams{Item: items[0]})
+	require.NoError(t, err)
+	require.Len(t, parents, 1)
+	assert.Equal(t, "expenses", parents[0].Name)
+	assert.Equal(t, docURI, parents[0].URI)
+
+	children, err := srv.Subtypes(context.Background(), &protocol.TypeHierarchySubtypesParams{Item: parents[0]})
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	assert.Equal(t, "expenses:food", children[0].Name)
+	assert.Equal(t, docURI, children[0].URI)
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -264,6 +264,23 @@ func (w *Workspace) GetResolvedForFile(path string) *include.ResolvedJournal {
 	return tree.Resolved
 }
 
+// GetIncludeTreesForFile returns all include trees that own path, sorted by
+// root path. Callers that depend on include context must use this instead of
+// GetResolvedForFile, which keeps its primary-root behavior for compatibility.
+func (w *Workspace) GetIncludeTreesForFile(path string) []*IncludeTree {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	roots := w.fileTree[path]
+	trees := make([]*IncludeTree, 0, len(roots))
+	for _, rootPath := range roots {
+		if tree := w.trees[rootPath]; tree != nil {
+			trees = append(trees, tree)
+		}
+	}
+	return trees
+}
+
 // GetUniqueResolvedForFile returns the resolved journal only when exactly one
 // include-tree root owns path. Callers that need an unambiguous transaction
 // context, such as running balance calculations, must use this method instead

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1298,6 +1298,24 @@ func TestWorkspace_GetUniqueResolvedForFile(t *testing.T) {
 	assert.Nil(t, resolved)
 }
 
+func TestWorkspace_GetIncludeTreesForFile_ReturnsAllOwnersInRootOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	childPath := filepath.Join(tmpDir, "child.journal")
+	firstRootPath := filepath.Join(tmpDir, "a-root.journal")
+	secondRootPath := filepath.Join(tmpDir, "b-root.journal")
+	require.NoError(t, os.WriteFile(childPath, []byte("account cash\n"), 0o644))
+	require.NoError(t, os.WriteFile(firstRootPath, []byte("include child.journal\n"), 0o644))
+	require.NoError(t, os.WriteFile(secondRootPath, []byte("include child.journal\n"), 0o644))
+
+	ws := NewWorkspace(tmpDir, include.NewLoader())
+	require.NoError(t, ws.Initialize())
+
+	trees := ws.GetIncludeTreesForFile(childPath)
+	require.Len(t, trees, 2)
+	assert.Equal(t, []string{firstRootPath, secondRootPath}, []string{trees[0].RootPath, trees[1].RootPath})
+	assert.NotSame(t, trees[0].Resolved, trees[1].Resolved)
+}
+
 func TestWorkspace_AllTrees(t *testing.T) {
 	t.Setenv("LEDGER_FILE", "")
 	t.Setenv("HLEDGER_JOURNAL", "")


### PR DESCRIPTION
## Summary

Preserves every valid account context when a journal belongs to multiple include trees. Type Hierarchy follow-up requests also work for non-file documents such as `untitled:`.

Closes #69

## Changes

- Add a deterministic workspace API that returns every include tree owning a file.
- Attach the owning root path to Type Hierarchy continuation data and keep follow-up requests bound to that root.
- Preserve the original document URI when no filesystem path exists.
- Reject stale or unknown root identities instead of falling back to another include context.
- Add regression tests for multiple roots, unknown roots, and `untitled:` documents.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -race ./...`
- `golangci-lint run ./...`
- `git diff --check`

## Code references

- `internal/server/type_hierarchy.go` — root-bound hierarchy data and URI-preserving candidates.
- `internal/server/type_hierarchy_test.go` — multi-root and non-file URI regressions.
- `internal/workspace/workspace.go` — deterministic lookup of every owning include tree.
- `internal/workspace/workspace_test.go` — owner ordering and distinct resolved journals.
