### PR TITLE
fix: inferred amount hints, code action filtering and UTF-16 columns

### DIFF
--- a/internal/document/text.go
+++ b/internal/document/text.go
@@ -19,6 +19,7 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/lsputil"
+	"github.com/juev/hledger-lsp/internal/textutil"
 )
 
 // node is one line in an implicit treap ordered by line index. size is the
@@ -92,17 +93,12 @@ type Text struct {
 
 // NewText builds a Text from content, normalizing CRLF/CR line endings to LF.
 func NewText(content string) *Text {
-	content = normalizeLF(content)
+	content = textutil.NormalizeLineEndings(content)
 	t := &Text{}
 	for _, line := range strings.Split(content, "\n") {
 		t.root = merge(t.root, newNode(line))
 	}
 	return t
-}
-
-func normalizeLF(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	return strings.ReplaceAll(s, "\r", "\n")
 }
 
 // LineCount returns the number of lines.

--- a/internal/include/loader.go
+++ b/internal/include/loader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/filetype"
 	"github.com/juev/hledger-lsp/internal/parser"
+	"github.com/juev/hledger-lsp/internal/textutil"
 )
 
 const (
@@ -83,7 +84,7 @@ func (l *Loader) LoadFromContent(path, content string) (*ResolvedJournal, []Load
 	if int64(len(content)) > limits.MaxFileSizeBytes {
 		return nil, []LoadError{{Kind: ErrorFileTooLarge, Path: path, SourcePath: path, Message: fmt.Sprintf("file too large: %d bytes (max %d)", len(content), limits.MaxFileSizeBytes)}}
 	}
-	return l.load(path, normalizeLineEndings(content), LoadOptions{Overlays: map[string]OverlayEntry{
+	return l.load(path, textutil.NormalizeLineEndings(content), LoadOptions{Overlays: map[string]OverlayEntry{
 		canonicalPath(path): {SourcePath: path, Content: content},
 	}})
 }
@@ -266,7 +267,7 @@ func (s *loadState) readIncluded(path string) (string, *LoadError) {
 		if int64(len(content)) > s.limits.MaxFileSizeBytes {
 			return "", &LoadError{Kind: ErrorFileTooLarge, Path: path, Message: fmt.Sprintf("included file too large: %d bytes (max %d)", len(content), s.limits.MaxFileSizeBytes)}
 		}
-		return normalizeLineEndings(content), nil
+		return textutil.NormalizeLineEndings(content), nil
 	}
 	canonical := canonicalPath(path)
 	s.loader.mu.RLock()
@@ -286,7 +287,7 @@ func (s *loadState) readIncluded(path string) (string, *LoadError) {
 	if err != nil {
 		return "", &LoadError{Kind: ErrorFileNotFound, Path: path, Message: fmt.Sprintf("cannot read included file: %v", err)}
 	}
-	content = normalizeLineEndings(string(raw))
+	content = textutil.NormalizeLineEndings(string(raw))
 	s.loader.mu.Lock()
 	s.loader.cache[canonical] = content
 	s.loader.mu.Unlock()
@@ -298,7 +299,7 @@ func (l *Loader) readRoot(path string, options LoadOptions) (string, *LoadError)
 		if int64(len(content)) > l.getLimits().MaxFileSizeBytes {
 			return "", &LoadError{Kind: ErrorFileTooLarge, Path: path, SourcePath: path, Message: fmt.Sprintf("file too large: %d bytes (max %d)", len(content), l.getLimits().MaxFileSizeBytes)}
 		}
-		return normalizeLineEndings(content), nil
+		return textutil.NormalizeLineEndings(content), nil
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -311,7 +312,7 @@ func (l *Loader) readRoot(path string, options LoadOptions) (string, *LoadError)
 	if err != nil {
 		return "", &LoadError{Kind: ErrorFileNotFound, Path: path, SourcePath: path, Message: fmt.Sprintf("cannot read file: %v", err)}
 	}
-	return normalizeLineEndings(string(raw)), nil
+	return textutil.NormalizeLineEndings(string(raw)), nil
 }
 
 func (l *Loader) expandGlob(basePath, pattern string) ([]string, error) {
@@ -352,11 +353,6 @@ func (l *Loader) InvalidateFile(path string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	delete(l.cache, canonicalPath(path))
-}
-
-func normalizeLineEndings(content string) string {
-	content = strings.ReplaceAll(content, "\r\n", "\n")
-	return strings.ReplaceAll(content, "\r", "\n")
 }
 
 func absoluteClean(path string) string {

--- a/internal/lsputil/mapper.go
+++ b/internal/lsputil/mapper.go
@@ -86,6 +86,22 @@ func (m *PositionMapper) LineUTF16Len(line int) int {
 	return UTF16Len(m.lines[line])
 }
 
+// LineEndPosition returns the position just past the last character of the
+// line. The line terminator is excluded, so in a CRLF document the position
+// points before the carriage return.
+func (m *PositionMapper) LineEndPosition(line int) protocol.Position {
+	if line < 0 {
+		return protocol.Position{Line: 0, Character: 0}
+	}
+	if line >= len(m.lines) {
+		return protocol.Position{Line: uint32(line), Character: 0}
+	}
+	return protocol.Position{
+		Line:      uint32(line),
+		Character: uint32(UTF16Len(strings.TrimSuffix(m.lines[line], "\r"))),
+	}
+}
+
 func (m *PositionMapper) LineRuneLen(line int) int {
 	if line < 0 || line >= len(m.lines) {
 		return 0
@@ -138,6 +154,28 @@ func UTF16OffsetToByteOffset(s string, utf16Offset int) int {
 		}
 	}
 	return byteOffset
+}
+
+// RuneOffsetToUTF16Offset converts a rune offset within s — the unit the lexer
+// reports columns in — to the UTF-16 code unit offset LSP positions use.
+func RuneOffsetToUTF16Offset(s string, runeOffset int) int {
+	if runeOffset <= 0 {
+		return 0
+	}
+	utf16Offset := 0
+	runes := 0
+	for _, r := range s {
+		if runes >= runeOffset {
+			return utf16Offset
+		}
+		if r >= 0x10000 {
+			utf16Offset += 2
+		} else {
+			utf16Offset++
+		}
+		runes++
+	}
+	return utf16Offset
 }
 
 // UTF16OffsetToRuneOffset converts an LSP UTF-16 character offset within s

--- a/internal/lsputil/mapper_test.go
+++ b/internal/lsputil/mapper_test.go
@@ -145,6 +145,30 @@ func TestPositionMapper_LineUTF16Len(t *testing.T) {
 	assert.Equal(t, 0, mapper.LineUTF16Len(10)) // out of bounds
 }
 
+func TestPositionMapper_LineEndPosition(t *testing.T) {
+	mapper := NewPositionMapper("hello\nПривет\na\U00010400b")
+
+	assert.Equal(t, protocol.Position{Line: 0, Character: 5}, mapper.LineEndPosition(0))
+	assert.Equal(t, protocol.Position{Line: 1, Character: 6}, mapper.LineEndPosition(1))
+	assert.Equal(t, protocol.Position{Line: 2, Character: 4}, mapper.LineEndPosition(2), "surrogate pair counts as two UTF-16 units")
+
+	crlf := NewPositionMapper("hello\r\nworld\r\n")
+	assert.Equal(t, protocol.Position{Line: 0, Character: 5}, crlf.LineEndPosition(0), "carriage return is not part of the line")
+	assert.Equal(t, protocol.Position{Line: 1, Character: 5}, crlf.LineEndPosition(1))
+
+	assert.Equal(t, protocol.Position{Line: 0, Character: 0}, mapper.LineEndPosition(-1))
+	assert.Equal(t, protocol.Position{Line: 10, Character: 0}, mapper.LineEndPosition(10))
+}
+
+func TestRuneOffsetToUTF16Offset(t *testing.T) {
+	assert.Equal(t, 0, RuneOffsetToUTF16Offset("hello", 0))
+	assert.Equal(t, 5, RuneOffsetToUTF16Offset("hello", 5))
+	assert.Equal(t, 5, RuneOffsetToUTF16Offset("hello", 99), "clamped to the end of the string")
+	assert.Equal(t, 0, RuneOffsetToUTF16Offset("hello", -1))
+	assert.Equal(t, 6, RuneOffsetToUTF16Offset("Привет:x", 6))
+	assert.Equal(t, 3, RuneOffsetToUTF16Offset("a\U00010400b", 2), "a supplementary rune spans two UTF-16 units")
+}
+
 func TestPositionMapper_LSPToByte(t *testing.T) {
 	content := "hello\nАктивы:Кошелек  100\nworld"
 	mapper := NewPositionMapper(content)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -102,13 +102,21 @@ type Parser struct {
 	initialCommodityDecimalMarks map[string]string
 }
 
+// Parse turns journal text into an AST. The input must already use LF line
+// endings — see ParseWithContext.
 func Parse(input string) (*ast.Journal, []ParseError) {
 	result, errs := ParseWithContext(input, Context{}, nil)
 	return result.Journal, errs
 }
 
+// ParseWithContext parses journal text that carries an outer parse context.
+//
+// The input must use LF line endings. Positions in the returned AST are
+// offsets into exactly the string passed in, and callers map them back to LSP
+// positions against that same string; normalizing here would instead give the
+// AST a coordinate system of its own and shift every position on a CRLF
+// document. Callers normalize on the way in — textutil.NormalizeLineEndings.
 func ParseWithContext(input string, initial Context, resolve IncludeResolver) (ParseResult, []ParseError) {
-	input = strings.ReplaceAll(input, "\r\n", "\n")
 	context := cloneContext(initial)
 	p := &Parser{
 		lexer:                        NewLexer(input),

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -3796,7 +3796,7 @@ func TestParser_BalanceAssertionWithAllAnnotationsCRLF(t *testing.T) {
 }
 
 func TestParseWithContext_OrdersEveryJournalNodeAndResolvesIncludes(t *testing.T) {
-	input := "; before\r\nY 2024\r\n2024-01-01 one\r\n    assets:cash\r\n~ monthly two\r\n    assets:cash\r\n= account:assets three\r\n    assets:cash\r\naccount Активы:Банк\r\ninclude child.journal\r\n; after\r\n"
+	input := strings.ReplaceAll("; before\r\nY 2024\r\n2024-01-01 one\r\n    assets:cash\r\n~ monthly two\r\n    assets:cash\r\n= account:assets three\r\n    assets:cash\r\naccount Активы:Банк\r\ninclude child.journal\r\n; after\r\n", "\r\n", "\n")
 
 	result, errs := ParseWithContext(input, Context{}, func(site IncludeSite) ContextExports {
 		assert.Equal(t, "child.journal", site.Include.Path)

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -9,17 +9,8 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/textutil"
 )
-
-// normalizeLineEndings converts \r\n and \r to \n.
-// The rules lexer assumes \n-only input. Files read from disk on Windows may
-// have CRLF. (Mirrors the copy in internal/include/loader.go; kept local to
-// avoid a cross-package dependency for a trivial two-line helper.)
-func normalizeLineEndings(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.ReplaceAll(s, "\r", "\n")
-	return s
-}
 
 const (
 	defaultMaxFileSizeBytes = 10 * 1024 * 1024
@@ -146,7 +137,7 @@ func (l *Loader) LoadWithOptions(path string, options LoadOptions) (*ResolvedRul
 	if rootErr != nil {
 		return nil, []LoadError{*rootErr}
 	}
-	rootContent = normalizeLineEndings(rootContent)
+	rootContent = textutil.NormalizeLineEndings(rootContent)
 
 	// Expand textually.
 	expander := &textExpander{
@@ -427,7 +418,7 @@ func (e *textExpander) expand(
 			errors = append(errors, *readErr)
 			continue
 		}
-		childContent = normalizeLineEndings(childContent)
+		childContent = textutil.NormalizeLineEndings(childContent)
 
 		// Recursively expand child.
 		expandedStart := out.Len()

--- a/internal/server/capabilities_test.go
+++ b/internal/server/capabilities_test.go
@@ -90,7 +90,7 @@ func TestServer_Initialize_CapabilityProfiles(t *testing.T) {
 			if tt.wantCodeActionOpts {
 				codeActionOptions, ok := result.Capabilities.CodeActionProvider.(*protocol.CodeActionOptions)
 				require.True(t, ok)
-				assert.Equal(t, []protocol.CodeActionKind{protocol.CodeActionKindQuickFix, "source.hledger"}, codeActionOptions.CodeActionKinds)
+				assert.Equal(t, []protocol.CodeActionKind{protocol.CodeActionKindQuickFix, insertInferredAmountKind, "source.hledger"}, codeActionOptions.CodeActionKinds)
 			} else {
 				assert.Equal(t, protocol.Boolean(true), result.Capabilities.CodeActionProvider)
 			}

--- a/internal/server/code_action.go
+++ b/internal/server/code_action.go
@@ -231,7 +231,7 @@ func (s *Server) quickFixForUnbalanced(
 		return protocol.CodeAction{}, false
 	}
 
-	tx := findTransactionForDiagnostic(journal.Transactions, diag.Range)
+	tx := findTransactionForDiagnostic(mapper, journal.Transactions, diag.Range)
 	if tx == nil {
 		return protocol.CodeAction{}, false
 	}
@@ -394,7 +394,7 @@ func (s *Server) executeFixUnbalanced(ctx context.Context, params *protocol.Exec
 		return nil, fmt.Errorf("failed to parse document")
 	}
 
-	tx := findTransactionByRange(journal.Transactions, txRange)
+	tx := findTransactionByRange(lsputil.NewPositionMapper(doc), journal.Transactions, txRange)
 	if tx == nil {
 		return nil, fmt.Errorf("transaction not found")
 	}
@@ -430,10 +430,10 @@ func (s *Server) executeFixUnbalanced(ctx context.Context, params *protocol.Exec
 	return nil, nil
 }
 
-func findTransactionByRange(transactions []ast.Transaction, target protocol.Range) *ast.Transaction {
+func findTransactionByRange(mapper *lsputil.PositionMapper, transactions []ast.Transaction, target protocol.Range) *ast.Transaction {
 	for i := range transactions {
-		r := astRangeToProtocol(transactions[i].Range)
-		if r != nil && *r == target {
+		r := astRangeToLSP(mapper, transactions[i].Range)
+		if r == target {
 			return &transactions[i]
 		}
 	}
@@ -527,10 +527,10 @@ func formatOutputAsComment(cmd, output string) string {
 	return builder.String()
 }
 
-func findTransactionForDiagnostic(transactions []ast.Transaction, rng protocol.Range) *ast.Transaction {
+func findTransactionForDiagnostic(mapper *lsputil.PositionMapper, transactions []ast.Transaction, rng protocol.Range) *ast.Transaction {
 	for i := range transactions {
-		txRange := astRangeToProtocol(transactions[i].Range)
-		if txRange != nil && rangesOverlap(*txRange, rng) {
+		txRange := astRangeToLSP(mapper, transactions[i].Range)
+		if rangesOverlap(txRange, rng) {
 			return &transactions[i]
 		}
 	}

--- a/internal/server/code_action.go
+++ b/internal/server/code_action.go
@@ -30,6 +30,25 @@ func stringPtr(value string) *string { return &value }
 
 func codeActionKind(value protocol.CodeActionKind) *protocol.CodeActionKind { return &value }
 
+// codeActionKindAllowed reports whether an action of this kind may be returned
+// for the given CodeActionContext.Only filter. Kinds form a dotted hierarchy,
+// so "quickfix" also selects "quickfix.hledger.insertInferredAmount". An empty
+// filter selects everything; an action without a kind matches no filter.
+func codeActionKindAllowed(kind *protocol.CodeActionKind, only []protocol.CodeActionKind) bool {
+	if len(only) == 0 {
+		return true
+	}
+	if kind == nil {
+		return false
+	}
+	for _, filter := range only {
+		if *kind == filter || strings.HasPrefix(string(*kind), string(filter)+".") {
+			return true
+		}
+	}
+	return false
+}
+
 func getHledgerCommands() []hledgerCommand {
 	return []hledgerCommand{
 		{cmd: "bal", title: "Run hledger bal (balance)"},
@@ -45,18 +64,42 @@ func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionPara
 		return nil, nil
 	}
 
-	actions, err := s.getCodeActions(params.TextDocument.URI)
-	if err != nil {
-		return nil, err
+	// Each source is skipped up front when the filter excludes its kind:
+	// quick fixes may run a full document analysis and the inferred-amount
+	// source parses and computes alignment, and a client asking for one kind
+	// should not pay for the others.
+	only := params.Context.Only
+
+	var actions []protocol.CodeAction
+	if codeActionKindAllowed(codeActionKind("source.hledger"), only) {
+		var err error
+		actions, err = s.getCodeActions(params.TextDocument.URI)
+		if err != nil {
+			return nil, err
+		}
 	}
-	quickFixes := s.getQuickFixCodeActions(params)
-	inferred := s.getInferredAmountCodeActions(params)
+	var quickFixes []protocol.CodeAction
+	if codeActionKindAllowed(codeActionKind(protocol.CodeActionKindQuickFix), only) {
+		quickFixes = s.getQuickFixCodeActions(params)
+	}
+	var inferred []protocol.CodeAction
+	if codeActionKindAllowed(codeActionKind(insertInferredAmountKind), only) {
+		inferred = s.getInferredAmountCodeActions(params)
+	}
 
 	generated := make([]protocol.CodeAction, 0, len(actions)+len(quickFixes)+len(inferred))
 	generated = append(generated, quickFixes...)
 	generated = append(generated, inferred...)
 	generated = append(generated, actions...)
-	return s.codeActionResult(generated), nil
+
+	// Filtered before codeActionResult: the command-only arm drops the kind.
+	filtered := generated[:0]
+	for _, action := range generated {
+		if codeActionKindAllowed(action.Kind, only) {
+			filtered = append(filtered, action)
+		}
+	}
+	return s.codeActionResult(filtered), nil
 }
 
 func (s *Server) codeActionResult(actions []protocol.CodeAction) []protocol.CommandOrCodeAction {

--- a/internal/server/code_action.go
+++ b/internal/server/code_action.go
@@ -50,9 +50,11 @@ func (s *Server) CodeAction(ctx context.Context, params *protocol.CodeActionPara
 		return nil, err
 	}
 	quickFixes := s.getQuickFixCodeActions(params)
+	inferred := s.getInferredAmountCodeActions(params)
 
-	generated := make([]protocol.CodeAction, 0, len(actions)+len(quickFixes))
+	generated := make([]protocol.CodeAction, 0, len(actions)+len(quickFixes)+len(inferred))
 	generated = append(generated, quickFixes...)
+	generated = append(generated, inferred...)
 	generated = append(generated, actions...)
 	return s.codeActionResult(generated), nil
 }

--- a/internal/server/code_action_inferred.go
+++ b/internal/server/code_action_inferred.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+
+	"github.com/juev/hledger-lsp/internal/ast"
+	"github.com/juev/hledger-lsp/internal/formatter"
+	"github.com/juev/hledger-lsp/internal/lsputil"
+)
+
+// insertInferredAmountKind marks the action that writes the amount hledger
+// would infer for an amountless posting into the document. Clients bind it to a
+// key by asking for this kind explicitly.
+const insertInferredAmountKind = protocol.CodeActionKind("quickfix.hledger.insertInferredAmount")
+
+// getInferredAmountCodeActions offers the inferred balancing amount of an
+// amountless posting as an edit aligned to the document's amount column. Unlike
+// the UNBALANCED quickfix it is not driven by a diagnostic — such a transaction
+// is valid hledger, there is simply nothing written down yet.
+func (s *Server) getInferredAmountCodeActions(params *protocol.CodeActionParams) []protocol.CodeAction {
+	doc, ok := s.getJournalDoc(params.TextDocument.URI)
+	if !ok {
+		return nil
+	}
+	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
+	if journal == nil || len(journal.Transactions) == 0 {
+		return nil
+	}
+
+	settings := s.getSettings()
+	lines := splitLines(doc)
+
+	// Alignment walks every transaction, and code actions are requested on
+	// every cursor move, so pay for it only once a posting actually qualifies.
+	var alignment formatter.AlignmentInfo
+	alignmentComputed := false
+	computeAlignment := func() formatter.AlignmentInfo {
+		if !alignmentComputed {
+			commodityFormats := formatter.ExtractCommodityFormats(journal.Directives)
+			if workspaceFormats := s.commodityFormatsForDocument(params.TextDocument.URI); workspaceFormats != nil {
+				commodityFormats = workspaceFormats
+			}
+			alignment = formatter.ComputeAlignment(journal, commodityFormats, formatterOptionsFrom(settings.Formatting))
+			alignmentComputed = true
+		}
+		return alignment
+	}
+
+	actions := make([]protocol.CodeAction, 0, 1)
+	for _, effect := range s.cachedPostingEffects(params.TextDocument.URI, doc) {
+		// A single edit cannot express a balance spanning several commodities.
+		if len(effect.InferredAmounts) != 1 {
+			continue
+		}
+		if effect.TransactionIndex >= len(journal.Transactions) {
+			continue
+		}
+		transaction := &journal.Transactions[effect.TransactionIndex]
+		if effect.PostingIndex >= len(transaction.Postings) {
+			continue
+		}
+		posting := &transaction.Postings[effect.PostingIndex]
+		if !postingLineInRange(posting, params.Range) {
+			continue
+		}
+
+		formats := localCommodityFormatsAt(journal, posting.Range.Start.Offset)
+		amountText := formatInferredAmount(transaction, effect.InferredAmounts, formats)
+		edit, ok := buildInferredAmountEdit(lines, posting, amountText, computeAlignment(), settings.Formatting)
+		if !ok {
+			continue
+		}
+
+		actions = append(actions, protocol.CodeAction{
+			Title: fmt.Sprintf("Insert inferred amount (%s)", amountText),
+			Kind:  codeActionKind(insertInferredAmountKind),
+			Edit: &protocol.WorkspaceEdit{
+				Changes: map[uri.URI][]protocol.TextEdit{params.TextDocument.URI: {edit}},
+			},
+		})
+	}
+
+	return actions
+}
+
+// formatInferredAmount renders the single inferred amount the way the
+// transaction already writes that commodity: same symbol position and at least
+// as many decimal places as its siblings. A commodity directive still wins,
+// because FormatAmount prefers a declared format over the raw quantity.
+func formatInferredAmount(
+	transaction *ast.Transaction,
+	amounts map[string]decimal.Decimal,
+	formats map[string]formatter.CommodityFormat,
+) string {
+	// The commodity may legitimately be the empty symbol: hledger journals that
+	// track a single currency often write bare numbers.
+	var commodity string
+	var quantity decimal.Decimal
+	found := false
+	for symbol, value := range amounts {
+		commodity, quantity, found = symbol, value, true
+	}
+	if !found {
+		return ""
+	}
+
+	amount := &ast.Amount{
+		Quantity:  quantity,
+		Commodity: ast.Commodity{Symbol: commodity, Position: ast.CommodityRight},
+	}
+	places := -quantity.Exponent()
+	for i := range transaction.Postings {
+		sibling := transaction.Postings[i].Amount
+		if sibling == nil || sibling.Commodity.Symbol != commodity {
+			continue
+		}
+		amount.Commodity.Position = sibling.Commodity.Position
+		amount.Commodity.Quoted = sibling.Commodity.Quoted
+		if siblingPlaces := -sibling.Quantity.Exponent(); siblingPlaces > places {
+			places = siblingPlaces
+		}
+		break
+	}
+	if places > 0 {
+		amount.RawQuantity = quantity.StringFixed(places)
+	}
+	if quantity.IsNegative() && amount.Commodity.Position == ast.CommodityLeft {
+		amount.SignBeforeCommodity = true
+	}
+
+	return formatter.FormatAmount(amount, formats)
+}
+
+// postingLineInRange reports whether the posting sits on one of the lines the
+// client asked about. Line granularity is deliberate: the request usually
+// carries a bare cursor position, which no range covering the amount column
+// would overlap.
+func postingLineInRange(posting *ast.Posting, requested protocol.Range) bool {
+	line := posting.Account.Range.End.Line - 1
+	return line >= int(requested.Start.Line) && line <= int(requested.End.Line)
+}
+
+// buildInferredAmountEdit replaces whatever whitespace follows the account name
+// with padding that puts the amount on the document's amount column. Anything
+// else on the line — a posting comment — is preserved after two spaces.
+func buildInferredAmountEdit(
+	lines []string,
+	posting *ast.Posting,
+	amountText string,
+	alignment formatter.AlignmentInfo,
+	formatting formattingSettings,
+) (protocol.TextEdit, bool) {
+	if amountText == "" || posting.Amount != nil {
+		return protocol.TextEdit{}, false
+	}
+
+	lineIndex := posting.Account.Range.End.Line - 1
+	if lineIndex < 0 || lineIndex >= len(lines) {
+		return protocol.TextEdit{}, false
+	}
+	line := strings.TrimSuffix(lines[lineIndex], "\r")
+
+	accountEnd := posting.Account.Range.End.Column - 1
+	accountEndByte := lsputil.UTF16OffsetToByteOffset(line, lsputil.RuneOffsetToUTF16Offset(line, accountEnd))
+	if accountEndByte < 0 || accountEndByte > len(line) {
+		return protocol.TextEdit{}, false
+	}
+
+	rest := line[accountEndByte:]
+	trailing := strings.TrimLeft(rest, " \t")
+	suffix := ""
+	if trailing != "" {
+		suffix = "  "
+	}
+
+	newText := strings.Repeat(" ", amountSpacesFromAlignment(accountEnd, amountText, alignment, formatting)) + amountText + suffix
+	startCharacter := lsputil.RuneOffsetToUTF16Offset(line, accountEnd)
+
+	return protocol.TextEdit{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: uint32(lineIndex), Character: uint32(startCharacter)},
+			End:   protocol.Position{Line: uint32(lineIndex), Character: uint32(startCharacter + len(rest) - len(trailing))},
+		},
+		NewText: newText,
+	}, true
+}

--- a/internal/server/code_action_inferred_test.go
+++ b/internal/server/code_action_inferred_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+const inferredTestURI = uri.URI("file:///test.journal")
+
+func inferredAmountActions(t *testing.T, ts *testServer, line uint32) []protocol.CodeAction {
+	t.Helper()
+	docURI := inferredTestURI
+	ts.clientCapabilities.supportsCodeActionLiterals = true
+
+	entries, err := ts.CodeAction(context.Background(), &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+		Range:        protocol.Range{Start: protocol.Position{Line: line}, End: protocol.Position{Line: line}},
+	})
+	require.NoError(t, err)
+
+	matched := make([]protocol.CodeAction, 0, 1)
+	for _, action := range codeActionEntries(entries) {
+		if action.Kind != nil && *action.Kind == insertInferredAmountKind {
+			matched = append(matched, action)
+		}
+	}
+	return matched
+}
+
+func requireSingleEdit(t *testing.T, action protocol.CodeAction) protocol.TextEdit {
+	t.Helper()
+	require.NotNil(t, action.Edit)
+	edits := action.Edit.Changes[inferredTestURI]
+	require.Len(t, edits, 1)
+	return edits[0]
+}
+
+func TestCodeAction_InsertInferredAmount_AlignsToAmountColumn(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	docURI := inferredTestURI
+	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n    Expenses:Food\n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	actions := inferredAmountActions(t, ts, 2)
+	require.Len(t, actions, 1)
+	assert.Equal(t, "Insert inferred amount (20.50 USD)", actions[0].Title)
+
+	edit := requireSingleEdit(t, actions[0])
+	assert.Equal(t, protocol.Position{Line: 2, Character: 17}, edit.Range.Start, "replaces from the end of the account name")
+	assert.Equal(t, protocol.Position{Line: 2, Character: 17}, edit.Range.End, "up to the end of the line")
+
+	// The sibling posting ends its amount at column 30, so the inserted amount
+	// must end there too.
+	assert.Equal(t, len("    Expenses:Food")+len(edit.NewText), len("    Expenses:Test  -20.50 USD"))
+}
+
+func TestCodeAction_InsertInferredAmount_ReplacesTabAlignmentPadding(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	docURI := inferredTestURI
+	// Trailing spaces are the padding the Tab alignment inserted before the
+	// user asked for the amount.
+	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n    Expenses:Food            \n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	actions := inferredAmountActions(t, ts, 2)
+	require.Len(t, actions, 1)
+
+	edit := requireSingleEdit(t, actions[0])
+	assert.Equal(t, uint32(17), edit.Range.Start.Character)
+	assert.Equal(t, uint32(len("    Expenses:Food            ")), edit.Range.End.Character, "the stale padding is replaced, not kept")
+	assert.Equal(t, len("    Expenses:Test  -20.50 USD"), len("    Expenses:Food"+edit.NewText), "the amount still ends on the document's amount column")
+}
+
+func TestCodeAction_InsertInferredAmount_SupportsAmountsWithoutCommodity(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	docURI := inferredTestURI
+	content := "2024-07-23 Метрополитен\n    Расходы:Транспорт  71.00\n    Активы:Сбербанк\n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	actions := inferredAmountActions(t, ts, 2)
+	require.Len(t, actions, 1)
+	assert.Equal(t, "Insert inferred amount (-71.00)", actions[0].Title)
+	assert.Contains(t, requireSingleEdit(t, actions[0]).NewText, "-71.00")
+}
+
+func TestCodeAction_InsertInferredAmount_NotOfferedWhenAmountPresent(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	docURI := inferredTestURI
+	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n    Expenses:Food   20.50 USD\n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	assert.Empty(t, inferredAmountActions(t, ts, 2))
+	assert.Empty(t, inferredAmountActions(t, ts, 1))
+}
+
+func TestCodeAction_InsertInferredAmount_SkipsMultiCommodityInference(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	docURI := inferredTestURI
+	content := "2026-08-03 Good\n    Expenses:One  $10\n    Expenses:Two  10 EUR\n    Assets:Cash\n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	assert.Empty(t, inferredAmountActions(t, ts, 3), "a single edit cannot express a multi-commodity balance")
+}
+
+func TestCodeAction_InsertInferredAmount_OnlyForRequestedRange(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	docURI := inferredTestURI
+	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n    Expenses:Food\n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	assert.Empty(t, inferredAmountActions(t, ts, 0))
+	assert.Len(t, inferredAmountActions(t, ts, 2), 1)
+}
+
+func TestCodeAction_InsertInferredAmount_IndependentOfInlayHintSettings(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	settings := ts.getSettings()
+	settings.Features.InlayHints = false
+	settings.InlayHints.InferredAmounts = false
+	ts.setSettings(settings)
+
+	docURI := inferredTestURI
+	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n    Expenses:Food\n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	assert.Len(t, inferredAmountActions(t, ts, 2), 1)
+}

--- a/internal/server/code_action_only_test.go
+++ b/internal/server/code_action_only_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+// onlyKinds asks for code actions on the amountless posting of a transaction
+// that also has an unbalanced sibling, so every action source can contribute.
+func onlyKinds(t *testing.T, only []protocol.CodeActionKind) []protocol.CodeActionKind {
+	t.Helper()
+
+	ts := newTestServer()
+	ts.clientCapabilities.supportsCodeActionLiterals = true
+	docURI := uri.URI("file:///test.journal")
+	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n    Expenses:Food\n"
+	require.NoError(t, ts.openDocument(docURI, content))
+
+	entries, err := ts.CodeAction(context.Background(), &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+		Range:        protocol.Range{Start: protocol.Position{Line: 2}, End: protocol.Position{Line: 2}},
+		Context:      protocol.CodeActionContext{Only: only},
+	})
+	require.NoError(t, err)
+
+	kinds := make([]protocol.CodeActionKind, 0)
+	for _, action := range codeActionEntries(entries) {
+		require.NotNil(t, action.Kind)
+		kinds = append(kinds, *action.Kind)
+	}
+	return kinds
+}
+
+func TestCodeAction_Only_ExactKind(t *testing.T) {
+	kinds := onlyKinds(t, []protocol.CodeActionKind{insertInferredAmountKind})
+
+	assert.Equal(t, []protocol.CodeActionKind{insertInferredAmountKind}, kinds)
+}
+
+func TestCodeAction_Only_ParentKindMatchesChildren(t *testing.T) {
+	kinds := onlyKinds(t, []protocol.CodeActionKind{protocol.CodeActionKindQuickFix})
+
+	assert.Contains(t, kinds, insertInferredAmountKind, "a dotted child of quickfix passes the quickfix filter")
+	assert.NotContains(t, kinds, protocol.CodeActionKind("source.hledger"))
+}
+
+func TestCodeAction_Only_SourceKind(t *testing.T) {
+	kinds := onlyKinds(t, []protocol.CodeActionKind{"source"})
+
+	require.NotEmpty(t, kinds)
+	for _, kind := range kinds {
+		assert.Equal(t, protocol.CodeActionKind("source.hledger"), kind)
+	}
+}
+
+func TestCodeAction_Only_UnrelatedKindReturnsNothing(t *testing.T) {
+	assert.Empty(t, onlyKinds(t, []protocol.CodeActionKind{"refactor.extract"}))
+}
+
+func TestCodeAction_Only_EmptyKeepsEveryKind(t *testing.T) {
+	kinds := onlyKinds(t, nil)
+
+	assert.Contains(t, kinds, insertInferredAmountKind)
+	assert.Contains(t, kinds, protocol.CodeActionKind("source.hledger"))
+}
+
+func TestCodeActionKindAllowed(t *testing.T) {
+	quickFix := protocol.CodeActionKindQuickFix
+
+	assert.True(t, codeActionKindAllowed(&quickFix, nil), "no filter accepts everything")
+	assert.True(t, codeActionKindAllowed(&quickFix, []protocol.CodeActionKind{"quickfix"}))
+	assert.True(t, codeActionKindAllowed(&insertInferredAmountKindValue, []protocol.CodeActionKind{"quickfix"}))
+	assert.False(t, codeActionKindAllowed(&quickFix, []protocol.CodeActionKind{"quickfix.hledger"}), "a child filter does not accept the parent")
+	assert.False(t, codeActionKindAllowed(&quickFix, []protocol.CodeActionKind{"quickfixes"}), "matching is on dotted segments, not raw prefixes")
+	assert.False(t, codeActionKindAllowed(nil, []protocol.CodeActionKind{"quickfix"}), "an action without a kind matches no filter")
+}
+
+var insertInferredAmountKindValue = insertInferredAmountKind

--- a/internal/server/code_action_only_test.go
+++ b/internal/server/code_action_only_test.go
@@ -17,6 +17,9 @@ func onlyKinds(t *testing.T, only []protocol.CodeActionKind) []protocol.CodeActi
 
 	ts := newTestServer()
 	ts.clientCapabilities.supportsCodeActionLiterals = true
+	// source.hledger actions are gated on the CLI being present; a fake keeps
+	// the filtering under test independent of what is installed.
+	ts.cliClient = &fakeCLIClient{available: true}
 	docURI := uri.URI("file:///test.journal")
 	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n    Expenses:Food\n"
 	require.NoError(t, ts.openDocument(docURI, content))

--- a/internal/server/codelens.go
+++ b/internal/server/codelens.go
@@ -10,6 +10,7 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/analyzer"
+	"github.com/juev/hledger-lsp/internal/lsputil"
 )
 
 func (s *Server) CodeLens(_ context.Context, params *protocol.CodeLensParams) ([]protocol.CodeLens, error) {
@@ -28,6 +29,7 @@ func (s *Server) CodeLens(_ context.Context, params *protocol.CodeLensParams) ([
 		return nil, nil
 	}
 
+	mapper := lsputil.NewPositionMapper(doc)
 	lenses := make([]protocol.CodeLens, 0, len(journal.Transactions))
 
 	for i := range journal.Transactions {
@@ -36,7 +38,7 @@ func (s *Server) CodeLens(_ context.Context, params *protocol.CodeLensParams) ([
 
 		title := buildCodeLensTitle(result, len(tx.Postings))
 		lens := protocol.CodeLens{
-			Range:   *astRangeToProtocol(tx.Date.Range),
+			Range:   astRangeToLSP(mapper, tx.Date.Range),
 			Command: protocol.Command{Title: title},
 		}
 		if !result.Balanced {
@@ -44,7 +46,7 @@ func (s *Server) CodeLens(_ context.Context, params *protocol.CodeLensParams) ([
 			// ExecuteCommand can re-resolve the exact transaction and apply the
 			// balance quickfix via workspace/applyEdit.
 			lens.Command.Command = "hledger.fixUnbalanced"
-			arguments, err := commandArguments(string(params.TextDocument.URI), *astRangeToProtocol(tx.Range))
+			arguments, err := commandArguments(string(params.TextDocument.URI), astRangeToLSP(mapper, tx.Range))
 			if err != nil {
 				return nil, fmt.Errorf("marshal code lens arguments: %w", err)
 			}

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -25,7 +25,7 @@ account expenses:food
     expenses:food  $50
     assets:cash`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -62,7 +62,7 @@ func TestCompletion_AccountsShowUsageCount(t *testing.T) {
 2024-01-18 new
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -110,7 +110,7 @@ func TestCompletion_PayeesShowUsageCount(t *testing.T) {
 
 2024-01-18 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -150,7 +150,7 @@ account assets:cash
     expenses:food:restaurant  $20
     assets:cash`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -186,7 +186,7 @@ func TestCompletion_Payees(t *testing.T) {
 
 2024-01-17 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -218,7 +218,7 @@ func TestCompletion_Commodities(t *testing.T) {
     expenses:rent  EUR 100
     assets:cash`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -295,7 +295,7 @@ account expenses:food
 2024-01-15 test
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -405,7 +405,7 @@ func TestCompletion_TagNames(t *testing.T) {
 
 2024-01-16 another ; `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -438,7 +438,7 @@ func TestCompletion_TagNames_NoDuplicates(t *testing.T) {
 
 2024-01-17 new ; `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -475,7 +475,7 @@ func TestCompletion_TagValues(t *testing.T) {
 
 2024-01-17 new ; project:`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -507,7 +507,7 @@ func TestCompletion_TagValues_OnlyForCurrentTag(t *testing.T) {
 
 2024-01-17 new ; status:`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -573,7 +573,7 @@ func TestCompletion_Date_BuiltIn(t *testing.T) {
 	srv := NewServer()
 	content := ``
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -609,7 +609,7 @@ func TestCompletion_Date_Historical(t *testing.T) {
 
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -637,7 +637,7 @@ func TestCompletion_Date_UsesFileFormat(t *testing.T) {
 
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -672,7 +672,7 @@ func TestCompletion_Date_UsesSlashSeparator(t *testing.T) {
 
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -705,7 +705,7 @@ func TestCompletion_Date_DefaultFormatWhenNoValidDates(t *testing.T) {
 account expenses:food
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -740,7 +740,7 @@ func TestCompletion_Date_UsesDotSeparator(t *testing.T) {
 
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -775,7 +775,7 @@ func TestCompletion_Date_WithoutLeadingZeros(t *testing.T) {
 
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -814,7 +814,7 @@ func TestCompletion_Date_HistoricalUsesFileFormat(t *testing.T) {
 
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -858,7 +858,7 @@ func TestCompletion_PayeeInsertsOnlyPayeeName(t *testing.T) {
 
 2024-01-15 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -902,7 +902,7 @@ func TestCompletion_MultiplePayeesShowCounts(t *testing.T) {
 
 2024-01-15 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -962,7 +962,7 @@ func TestCompletion_RankingByFrequency(t *testing.T) {
 
 2024-01-05 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1018,7 +1018,7 @@ func TestCompletion_AccountsRankingByFrequency(t *testing.T) {
 2024-01-05 Test5
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1090,7 +1090,7 @@ func TestCompletion_MaxResultsPreservesFrequent(t *testing.T) {
 
 2024-01-06 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1138,7 +1138,7 @@ func TestCompletion_MaxResultsAccountsPreservesFrequent(t *testing.T) {
 2024-01-05 Test5
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1240,7 +1240,7 @@ func TestCompletion_IsIncompleteAlwaysTrue(t *testing.T) {
     expenses:food  $50
     assets:cash`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1268,7 +1268,7 @@ func TestCompletion_FilterTextSameForAllItems(t *testing.T) {
 2024-01-16 another
     exp`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1491,7 +1491,7 @@ func TestCompletion_FiltersAndSortsByFrequency(t *testing.T) {
 2024-01-04 Test4
     альа`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1547,7 +1547,7 @@ func TestCompletion_ConsecutiveMatchBeforeSparse(t *testing.T) {
 2024-01-05 Test5
     альф`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1661,7 +1661,7 @@ commodity RUB
 2024-01-15 test
     expenses:food  100 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1691,7 +1691,7 @@ account expenses:food
 
 account `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1719,7 +1719,7 @@ func TestCompletion_DirectiveCommodity(t *testing.T) {
 
 commodity U`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1779,7 +1779,7 @@ account expenses:food
 2024-01-15 test
     exp`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -1818,7 +1818,7 @@ func TestCompletion_AccountMidWord_ReplacesFullToken(t *testing.T) {
 	srv := NewServer()
 	content := "account expenses:food:supermarket\naccount expenses:food:electronics\n\n2024-01-15 test\n    expenses:food:supermarket"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	// Cursor right after "food:" at "expenses:food:|supermarket" — UTF-16 col 18
 	params := &protocol.CompletionParams{
@@ -2016,7 +2016,7 @@ func TestCompletion_PayeeWithoutTemplate(t *testing.T) {
 
 2024-01-15 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2134,7 +2134,7 @@ func TestCompletion_Date_UsesNearbyFormat(t *testing.T) {
 
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2267,7 +2267,7 @@ func TestCompletion_PartialDateReturnsDates(t *testing.T) {
 
 2026-`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2311,7 +2311,7 @@ func TestCompletion_PartialDateOverridesFileFormat(t *testing.T) {
 
 2026-`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2351,7 +2351,7 @@ func TestCompletion_ShortDateKeepsShortFormat(t *testing.T) {
 
 ` + prefix
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2418,7 +2418,7 @@ commodity RUB
 2024-01-15 test
     expenses:food  `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2617,7 +2617,7 @@ func TestCompletion_PayeeWithTab(t *testing.T) {
 	srv := NewServer()
 	content := "2024-01-15 Grocery Store\n    expenses:food  $50\n    assets:cash\n\n2024-01-16\t"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2850,7 +2850,7 @@ func TestCompletion_IncludeNotes_True_ShowsFullDescription(t *testing.T) {
 
 2024-01-16 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2884,7 +2884,7 @@ func TestCompletion_IncludeNotes_False_ShowsPayeeOnly(t *testing.T) {
 
 2024-01-16 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2915,7 +2915,7 @@ func TestCompletion_IncludeNotes_DefaultTrue(t *testing.T) {
 
 2024-01-16 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2944,7 +2944,7 @@ func TestCompletion_ExcludesCurrentTransactionAccounts(t *testing.T) {
 2024-01-16 new
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -2972,7 +2972,7 @@ func TestCompletion_ExcludesCurrentTransactionPayee(t *testing.T) {
 
 2024-01-16 Groc`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3003,7 +3003,7 @@ func TestCompletion_CursorBetweenTransactions(t *testing.T) {
     assets:cash
 `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3038,7 +3038,7 @@ account assets:cash
 2024-01-15 test
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3269,7 +3269,7 @@ func TestCompletion_DigitTriggerOnEmptyLine(t *testing.T) {
 
 2`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3303,7 +3303,7 @@ func TestCompletion_DigitTriggerPartialYear(t *testing.T) {
 
 202`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3338,7 +3338,7 @@ func TestCompletion_DigitTriggerInPostingDoesNotReturnDates(t *testing.T) {
     expenses:food  $5
     assets:cash`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3365,7 +3365,7 @@ func TestCompletion_DigitTriggerInPayeeArea(t *testing.T) {
 	srv := NewServer()
 	content := `2024-01-10 3`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3392,7 +3392,7 @@ func TestCompletion_DigitTriggerOnEmptyDocument(t *testing.T) {
 	srv := NewServer()
 	content := `2`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3492,7 +3492,7 @@ func TestCompletion_Directive_TypingAccProducesAccount(t *testing.T) {
 	srv := NewServer()
 	content := "acc"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3525,7 +3525,7 @@ func TestCompletion_Directive_InsertTextHasTrailingSpace(t *testing.T) {
 	srv := NewServer()
 	content := "inc"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3553,7 +3553,7 @@ func TestCompletion_Directive_TextEditFromColumnZero(t *testing.T) {
 	srv := NewServer()
 	content := "acc"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3583,7 +3583,7 @@ func TestCompletion_Directive_FuzzyFiltering(t *testing.T) {
 	srv := NewServer()
 	content := "com"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3609,7 +3609,7 @@ func TestCompletion_Directive_AllDirectivesShownOnSingleLetter(t *testing.T) {
 	srv := NewServer()
 	content := "2024-01-15 test\n    expenses:food  $50\n    assets:cash\n\na"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3634,7 +3634,7 @@ func TestCompletion_Directive_MultiWordDirective(t *testing.T) {
 	srv := NewServer()
 	content := "app"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3693,7 +3693,7 @@ func TestCompletion_Directive_CRLF(t *testing.T) {
 	srv := NewServer()
 	content := "2024-01-15 test\r\n    expenses:food  $50\r\n    assets:cash\r\n\r\nacc"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3716,7 +3716,7 @@ func TestCompletion_Directive_BlockDirectiveNewlineInsertText(t *testing.T) {
 	srv := NewServer()
 	content := "com"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3744,7 +3744,7 @@ func TestCompletion_Directive_TextEditCoversFullLine(t *testing.T) {
 	srv := NewServer()
 	content := "apply a"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3787,7 +3787,7 @@ func TestCompletion_TagName_TextEditRange(t *testing.T) {
 
 2024-01-16 another ; proj`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3828,7 +3828,7 @@ func TestCompletion_TagValue_TextEditRange(t *testing.T) {
 
 2024-01-17 new ; project:al`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3863,7 +3863,7 @@ func TestCompletion_TagName_FuzzyMatch(t *testing.T) {
 
 2024-01-16 another ; proj`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3955,7 +3955,7 @@ func TestCompletion_TagName_CRLF(t *testing.T) {
 	srv := NewServer()
 	content := "2024-01-15 test  ; project:alpha, status:done\r\n    expenses:food  $50\r\n    assets:cash\r\n\r\n2024-01-16 another ; proj"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -3978,7 +3978,7 @@ func TestCompletion_TagValue_CRLF(t *testing.T) {
 	srv := NewServer()
 	content := "2024-01-15 test1  ; project:alpha\r\n    expenses:food  $50\r\n    assets:cash\r\n\r\n2024-01-16 test2  ; project:beta\r\n    expenses:rent  $1000\r\n    assets:bank\r\n\r\n2024-01-17 new ; project:"
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -4006,7 +4006,7 @@ func TestCompletion_TagName_PostingComment(t *testing.T) {
 2024-01-16 another
     expenses:rent  $1000  ; `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -4037,7 +4037,7 @@ func TestCompletion_TagValue_PostingComment(t *testing.T) {
 2024-01-16 another
     expenses:rent  $1000  ; project:`
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -4101,7 +4101,7 @@ func TestCompletion_PayeeAwareAccountRanking(t *testing.T) {
 2024-01-04 Grocery Store
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -4151,7 +4151,7 @@ func TestCompletion_PayeeAwareRanking_UnknownPayeeFallsBackToGlobal(t *testing.T
 2024-01-04 Unknown Place
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
@@ -4205,7 +4205,7 @@ func TestCompletion_PayeeAwareRanking_RecencyTiebreaker(t *testing.T) {
 2024-05-01 Grocery Store
     `
 
-	srv.documents.Store(uri.URI("file:///test.journal"), content)
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
 
 	params := &protocol.CompletionParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{

--- a/internal/server/definition.go
+++ b/internal/server/definition.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/lsputil"
 )
 
 type DefinitionContext int
@@ -34,7 +35,8 @@ func (s *Server) definition(_ context.Context, params *protocol.DefinitionParams
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 
-	target := findDefinitionTarget(journal, params.Position)
+	mapper := lsputil.NewPositionMapper(doc)
+	target := findDefinitionTarget(mapper, journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {
 		return nil, nil
 	}
@@ -42,7 +44,7 @@ func (s *Server) definition(_ context.Context, params *protocol.DefinitionParams
 	resolved := s.getWorkspaceResolved(params.TextDocument.URI)
 	currentPath := uriToPath(params.TextDocument.URI)
 
-	location := findDefinitionLocation(target, resolved, currentPath, journal)
+	location := findDefinitionLocation(target, resolved, currentPath, journal, s.newMapperCache())
 	if location == nil {
 		return nil, nil
 	}
@@ -50,7 +52,7 @@ func (s *Server) definition(_ context.Context, params *protocol.DefinitionParams
 	return []protocol.Location{*location}, nil
 }
 
-func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definitionTarget {
+func findDefinitionTarget(mapper *lsputil.PositionMapper, journal *ast.Journal, pos protocol.Position) *definitionTarget {
 	for _, dir := range journal.Directives {
 		switch d := dir.(type) {
 		case ast.AccountDirective:
@@ -59,7 +61,7 @@ func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definiti
 				return &definitionTarget{
 					context:     DefContextAccount,
 					name:        d.Account.Name,
-					symbolRange: astRangeToProtocol(accountRange),
+					symbolRange: rangePtr(astRangeToLSP(mapper, accountRange)),
 				}
 			}
 		case ast.CommodityDirective:
@@ -69,7 +71,7 @@ func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definiti
 					return &definitionTarget{
 						context:     DefContextCommodity,
 						name:        d.Commodity.Symbol,
-						symbolRange: astRangeToProtocol(commodityRange),
+						symbolRange: rangePtr(astRangeToLSP(mapper, commodityRange)),
 					}
 				}
 			}
@@ -78,7 +80,7 @@ func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definiti
 				return &definitionTarget{
 					context:     DefContextPayee,
 					name:        d.Name,
-					symbolRange: astRangeToProtocol(d.Range),
+					symbolRange: rangePtr(astRangeToLSP(mapper, d.Range)),
 				}
 			}
 		}
@@ -94,7 +96,7 @@ func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definiti
 				return &definitionTarget{
 					context:     DefContextPayee,
 					name:        payee,
-					symbolRange: astRangeToProtocol(payeeRange),
+					symbolRange: rangePtr(astRangeToLSP(mapper, payeeRange)),
 				}
 			}
 		}
@@ -107,7 +109,7 @@ func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definiti
 				return &definitionTarget{
 					context:     DefContextAccount,
 					name:        p.Account.Name,
-					symbolRange: astRangeToProtocol(accountRange),
+					symbolRange: rangePtr(astRangeToLSP(mapper, accountRange)),
 				}
 			}
 
@@ -116,7 +118,7 @@ func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definiti
 					return &definitionTarget{
 						context:     DefContextCommodity,
 						name:        p.Amount.Commodity.Symbol,
-						symbolRange: astRangeToProtocol(p.Amount.Commodity.Range),
+						symbolRange: rangePtr(astRangeToLSP(mapper, p.Amount.Commodity.Range)),
 					}
 				}
 			}
@@ -126,20 +128,20 @@ func findDefinitionTarget(journal *ast.Journal, pos protocol.Position) *definiti
 	return nil
 }
 
-func findDefinitionLocation(target *definitionTarget, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal) *protocol.Location {
+func findDefinitionLocation(target *definitionTarget, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, mappers *mapperCache) *protocol.Location {
 	switch target.context {
 	case DefContextAccount:
-		return findAccountDefinitionResolved(target.name, resolved, currentPath, currentJournal)
+		return findAccountDefinitionResolved(target.name, resolved, currentPath, currentJournal, mappers)
 	case DefContextCommodity:
-		return findCommodityDefinitionResolved(target.name, resolved, currentPath, currentJournal)
+		return findCommodityDefinitionResolved(target.name, resolved, currentPath, currentJournal, mappers)
 	case DefContextPayee:
-		return findPayeeDefinitionResolved(target.name, resolved, currentPath, currentJournal)
+		return findPayeeDefinitionResolved(target.name, resolved, currentPath, currentJournal, mappers)
 	default:
 		return nil
 	}
 }
 
-func findAccountDefinitionResolved(name string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal) *protocol.Location {
+func findAccountDefinitionResolved(name string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, mappers *mapperCache) *protocol.Location {
 	journals := allJournalsWithPaths(resolved, currentPath, currentJournal)
 
 	for _, filePath := range sortedJournalPaths(journals) {
@@ -149,17 +151,17 @@ func findAccountDefinitionResolved(name string, resolved *include.ResolvedJourna
 				if ad.Account.Name == name {
 					return &protocol.Location{
 						URI:   pathToURI(filePath),
-						Range: *astRangeToProtocol(ad.Range),
+						Range: mappers.rangeIn(filePath, ad.Range),
 					}
 				}
 			}
 		}
 	}
 
-	return findFirstAccountUsageResolved(name, journals)
+	return findFirstAccountUsageResolved(name, journals, mappers)
 }
 
-func findFirstAccountUsageResolved(name string, journals map[string]*ast.Journal) *protocol.Location {
+func findFirstAccountUsageResolved(name string, journals map[string]*ast.Journal, mappers *mapperCache) *protocol.Location {
 	var earliest *protocol.Location
 	var earliestDate *ast.Date
 
@@ -174,7 +176,7 @@ func findFirstAccountUsageResolved(name string, journals map[string]*ast.Journal
 						earliestDate = &tx.Date
 						earliest = &protocol.Location{
 							URI:   pathToURI(filePath),
-							Range: *astRangeToProtocol(computeAccountRange(&p.Account)),
+							Range: mappers.rangeIn(filePath, computeAccountRange(&p.Account)),
 						}
 					}
 				}
@@ -185,7 +187,7 @@ func findFirstAccountUsageResolved(name string, journals map[string]*ast.Journal
 	return earliest
 }
 
-func findCommodityDefinitionResolved(symbol string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal) *protocol.Location {
+func findCommodityDefinitionResolved(symbol string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, mappers *mapperCache) *protocol.Location {
 	journals := allJournalsWithPaths(resolved, currentPath, currentJournal)
 
 	for _, filePath := range sortedJournalPaths(journals) {
@@ -195,17 +197,17 @@ func findCommodityDefinitionResolved(symbol string, resolved *include.ResolvedJo
 				if cd.Commodity.Symbol == symbol {
 					return &protocol.Location{
 						URI:   pathToURI(filePath),
-						Range: *astRangeToProtocol(cd.Range),
+						Range: mappers.rangeIn(filePath, cd.Range),
 					}
 				}
 			}
 		}
 	}
 
-	return findFirstCommodityUsageResolved(symbol, journals)
+	return findFirstCommodityUsageResolved(symbol, journals, mappers)
 }
 
-func findFirstCommodityUsageResolved(symbol string, journals map[string]*ast.Journal) *protocol.Location {
+func findFirstCommodityUsageResolved(symbol string, journals map[string]*ast.Journal, mappers *mapperCache) *protocol.Location {
 	var earliest *protocol.Location
 	var earliestDate *ast.Date
 
@@ -220,7 +222,7 @@ func findFirstCommodityUsageResolved(symbol string, journals map[string]*ast.Jou
 						earliestDate = &tx.Date
 						earliest = &protocol.Location{
 							URI:   pathToURI(filePath),
-							Range: *astRangeToProtocol(p.Amount.Commodity.Range),
+							Range: mappers.rangeIn(filePath, p.Amount.Commodity.Range),
 						}
 					}
 				}
@@ -231,7 +233,7 @@ func findFirstCommodityUsageResolved(symbol string, journals map[string]*ast.Jou
 	return earliest
 }
 
-func findPayeeDefinitionResolved(payee string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal) *protocol.Location {
+func findPayeeDefinitionResolved(payee string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, mappers *mapperCache) *protocol.Location {
 	journals := allJournalsWithPaths(resolved, currentPath, currentJournal)
 
 	var earliest *protocol.Location
@@ -247,7 +249,7 @@ func findPayeeDefinitionResolved(payee string, resolved *include.ResolvedJournal
 					earliestDate = &tx.Date
 					earliest = &protocol.Location{
 						URI:   pathToURI(filePath),
-						Range: *astRangeToProtocol(tx.Range),
+						Range: mappers.rangeIn(filePath, tx.Range),
 					}
 				}
 			}

--- a/internal/server/highlight.go
+++ b/internal/server/highlight.go
@@ -6,6 +6,7 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/ast"
+	"github.com/juev/hledger-lsp/internal/lsputil"
 )
 
 func (s *Server) DocumentHighlight(_ context.Context, params *protocol.DocumentHighlightParams) ([]protocol.DocumentHighlight, error) {
@@ -16,30 +17,31 @@ func (s *Server) DocumentHighlight(_ context.Context, params *protocol.DocumentH
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 
-	target := findDefinitionTarget(journal, params.Position)
+	mapper := lsputil.NewPositionMapper(doc)
+	target := findDefinitionTarget(mapper, journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {
 		return nil, nil
 	}
 
 	switch target.context {
 	case DefContextAccount:
-		return findAccountHighlights(journal, target.name), nil
+		return findAccountHighlights(mapper, journal, target.name), nil
 	case DefContextCommodity:
-		return findCommodityHighlights(journal, target.name), nil
+		return findCommodityHighlights(mapper, journal, target.name), nil
 	case DefContextPayee:
-		return findPayeeHighlights(journal, target.name), nil
+		return findPayeeHighlights(mapper, journal, target.name), nil
 	default:
 		return nil, nil
 	}
 }
 
-func findAccountHighlights(journal *ast.Journal, name string) []protocol.DocumentHighlight {
+func findAccountHighlights(mapper *lsputil.PositionMapper, journal *ast.Journal, name string) []protocol.DocumentHighlight {
 	var highlights []protocol.DocumentHighlight
 
 	for _, dir := range journal.Directives {
 		if ad, ok := dir.(ast.AccountDirective); ok && ad.Account.Name == name {
 			highlights = append(highlights, protocol.DocumentHighlight{
-				Range: *astRangeToProtocol(ensureRangeEnd(ad.Account.Range, ad.Account.Name)),
+				Range: astRangeToLSP(mapper, ensureRangeEnd(ad.Account.Range, ad.Account.Name)),
 				Kind:  protocol.DocumentHighlightKindText,
 			})
 		}
@@ -51,7 +53,7 @@ func findAccountHighlights(journal *ast.Journal, name string) []protocol.Documen
 			p := &tx.Postings[j]
 			if p.Account.Name == name {
 				highlights = append(highlights, protocol.DocumentHighlight{
-					Range: *astRangeToProtocol(computeAccountRange(&p.Account)),
+					Range: astRangeToLSP(mapper, computeAccountRange(&p.Account)),
 					Kind:  protocol.DocumentHighlightKindRead,
 				})
 			}
@@ -64,13 +66,13 @@ func findAccountHighlights(journal *ast.Journal, name string) []protocol.Documen
 	return highlights
 }
 
-func findCommodityHighlights(journal *ast.Journal, symbol string) []protocol.DocumentHighlight {
+func findCommodityHighlights(mapper *lsputil.PositionMapper, journal *ast.Journal, symbol string) []protocol.DocumentHighlight {
 	var highlights []protocol.DocumentHighlight
 
 	for _, dir := range journal.Directives {
 		if cd, ok := dir.(ast.CommodityDirective); ok && cd.Commodity.Symbol == symbol {
 			highlights = append(highlights, protocol.DocumentHighlight{
-				Range: *astRangeToProtocol(ensureRangeEnd(cd.Commodity.Range, cd.Commodity.Symbol)),
+				Range: astRangeToLSP(mapper, ensureRangeEnd(cd.Commodity.Range, cd.Commodity.Symbol)),
 				Kind:  protocol.DocumentHighlightKindText,
 			})
 		}
@@ -82,7 +84,7 @@ func findCommodityHighlights(journal *ast.Journal, symbol string) []protocol.Doc
 			p := &tx.Postings[j]
 			if p.Amount != nil && p.Amount.Commodity.Symbol == symbol {
 				highlights = append(highlights, protocol.DocumentHighlight{
-					Range: *astRangeToProtocol(p.Amount.Commodity.Range),
+					Range: astRangeToLSP(mapper, p.Amount.Commodity.Range),
 					Kind:  protocol.DocumentHighlightKindRead,
 				})
 			}
@@ -95,7 +97,7 @@ func findCommodityHighlights(journal *ast.Journal, symbol string) []protocol.Doc
 	return highlights
 }
 
-func findPayeeHighlights(journal *ast.Journal, payee string) []protocol.DocumentHighlight {
+func findPayeeHighlights(mapper *lsputil.PositionMapper, journal *ast.Journal, payee string) []protocol.DocumentHighlight {
 	var highlights []protocol.DocumentHighlight
 
 	for i := range journal.Transactions {
@@ -103,7 +105,7 @@ func findPayeeHighlights(journal *ast.Journal, payee string) []protocol.Document
 		txPayee := getPayeeOrDescription(tx)
 		if txPayee == payee {
 			highlights = append(highlights, protocol.DocumentHighlight{
-				Range: *astRangeToProtocol(payeeRange(tx, payee)),
+				Range: astRangeToLSP(mapper, payeeRange(tx, payee)),
 				Kind:  protocol.DocumentHighlightKindRead,
 			})
 		}

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -190,7 +190,9 @@ func computeDateRange(tx *ast.Transaction) ast.Range {
 }
 
 func computeAccountRange(account *ast.Account) ast.Range {
-	return account.Range
+	// Account directives leave the end unset, which would otherwise travel to
+	// the client as a range ending at character 0.
+	return ensureRangeEnd(account.Range, account.Name)
 }
 
 func getPayeeOrDescription(tx *ast.Transaction) string {
@@ -455,14 +457,19 @@ func countPostingsForAccountInTransactions(accountName string, transactions []as
 func ensureRangeEnd(rng ast.Range, name string) ast.Range {
 	if rng.End.Line == 0 && rng.End.Column == 0 && rng.Start.Line > 0 {
 		rng.End = ast.Position{
-			Line:   rng.Start.Line,
-			Column: rng.Start.Column + lsputil.UTF16Len(name),
+			Line: rng.Start.Line,
+			// The lexer counts columns in runes; converting to the UTF-16 units
+			// LSP wants happens at the protocol boundary, not here.
+			Column: rng.Start.Column + utf8.RuneCountInString(name),
 			Offset: rng.Start.Offset + len(name),
 		}
 	}
 	return rng
 }
 
+// astRangeToProtocol reads lexer columns as LSP characters, which only holds
+// while the line has no character outside the BMP. Prefer astRangeToLSP, which
+// goes through byte offsets and a PositionMapper.
 func astRangeToProtocol(rng ast.Range) *protocol.Range {
 	return &protocol.Range{
 		Start: protocol.Position{

--- a/internal/server/inlay_hint.go
+++ b/internal/server/inlay_hint.go
@@ -61,8 +61,13 @@ func (s *Server) InlayHint(_ context.Context, params *protocol.InlayHintParams) 
 			}
 		}
 		if settings.InlayHints.InferredAmounts && len(effect.InferredAmounts) > 0 {
+			// Anchored past the end of the line rather than after the account
+			// name: an inlay hint takes up room in the rendered line, so a hint
+			// placed mid-line pushes the alignment padding — and the cursor
+			// waiting at the amount column — to the right.
+			accountEnd := mapper.ByteToLSP(posting.Account.Range.End.Offset)
 			hints = appendHintInRange(hints, params.Range, protocol.InlayHint{
-				Position:    mapper.ByteToLSP(posting.Account.Range.End.Offset),
+				Position:    mapper.LineEndPosition(int(accountEnd.Line)),
 				Label:       protocol.String("= " + formatAmounts(effect.InferredAmounts, formats)),
 				Kind:        protocol.InlayHintKindType,
 				PaddingLeft: boolPtr(true),

--- a/internal/server/inlay_hint_test.go
+++ b/internal/server/inlay_hint_test.go
@@ -28,6 +28,27 @@ func TestInlayHint_LocalInferredAmount(t *testing.T) {
 	assert.True(t, *hints[0].PaddingLeft)
 }
 
+func TestInlayHint_InferredAmountAnchoredAtLineEnd(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///test.journal")
+	// The trailing spaces are the alignment padding Tab inserts before the user
+	// types the amount. Anchoring the hint inside the line would shift that
+	// padding — and the cursor sitting at its end — to the right.
+	lastLine := "    Expenses:Food          "
+	content := "2026-08-03 Good\n    Expenses:Test  -20.50 USD\n" + lastLine + "\n"
+	srv.StoreDocument(docURI, content)
+
+	hints, err := srv.InlayHint(context.Background(), &protocol.InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+		Range:        protocol.Range{End: protocol.Position{Line: 10}},
+	})
+	require.NoError(t, err)
+	require.Len(t, hints, 1)
+	assert.Equal(t, protocol.String("= 20.5 USD"), hints[0].Label)
+	assert.Equal(t, uint32(2), hints[0].Position.Line)
+	assert.Equal(t, uint32(len(lastLine)), hints[0].Position.Character)
+}
+
 func TestInlayHint_CostAndChronologicalRunningBalance(t *testing.T) {
 	srv := NewServer()
 	settings := srv.getSettings()
@@ -102,7 +123,8 @@ func TestInlayHint_UsesUTF16PositionAndCRLF(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, hints, 1)
 	assert.Equal(t, uint32(2), hints[0].Position.Line)
-	assert.Equal(t, uint32(13), hints[0].Position.Character)
+	// End of "    assets:cash", the carriage return excluded.
+	assert.Equal(t, uint32(15), hints[0].Position.Character)
 }
 
 func TestInlayHint_InferFinalPostingAtEOF(t *testing.T) {

--- a/internal/server/inline_completion.go
+++ b/internal/server/inline_completion.go
@@ -196,7 +196,8 @@ func buildInlinePostingsText(postings []analyzer.PostingTemplate, formatting for
 
 		amountText := renderInlineAmount(p)
 		if amountText != "" {
-			spaces := inlineAmountSpacesFromAlignment(p, amountText, alignment, formatting, indent)
+			accountEnd := utf8.RuneCountInString(indent) + utf8.RuneCountInString(p.Account)
+			spaces := amountSpacesFromAlignment(accountEnd, amountText, alignment, formatting)
 			sb.WriteString(strings.Repeat(" ", spaces))
 			sb.WriteString(amountText)
 		}
@@ -222,17 +223,15 @@ func renderInlineAmount(p analyzer.PostingTemplate) string {
 	return sb.String()
 }
 
-// inlineAmountSpacesFromAlignment returns the gap between the rendered account
-// and the rendered amount such that the amount lands on the same column the
-// formatter would produce for this document. Falls back to 2 spaces when
-// alignment is disabled or no usable column was computed.
-func inlineAmountSpacesFromAlignment(p analyzer.PostingTemplate, amountText string, alignment formatter.AlignmentInfo, formatting formattingSettings, indent string) int {
+// amountSpacesFromAlignment returns the gap between an account ending at
+// accountEnd (a rune column) and the rendered amount such that the amount lands
+// on the same column the formatter would produce for this document. Falls back
+// to 2 spaces when alignment is disabled or no usable column was computed.
+func amountSpacesFromAlignment(accountEnd int, amountText string, alignment formatter.AlignmentInfo, formatting formattingSettings) int {
 	const minSpaces = 2
 	if !formatting.AlignAmounts {
 		return minSpaces
 	}
-
-	accountEnd := utf8.RuneCountInString(indent) + utf8.RuneCountInString(p.Account)
 
 	switch formatting.AmountAlignmentMode {
 	case "decimal":

--- a/internal/server/links.go
+++ b/internal/server/links.go
@@ -7,6 +7,7 @@ import (
 	"go.lsp.dev/protocol"
 
 	"github.com/juev/hledger-lsp/internal/filetype"
+	"github.com/juev/hledger-lsp/internal/lsputil"
 	"github.com/juev/hledger-lsp/internal/rules"
 )
 
@@ -32,6 +33,7 @@ func (s *Server) DocumentLink(ctx context.Context, params *protocol.DocumentLink
 		return []protocol.DocumentLink{}, nil
 	}
 
+	mapper := lsputil.NewPositionMapper(doc)
 	var links []protocol.DocumentLink
 
 	for _, inc := range journal.Includes {
@@ -44,7 +46,7 @@ func (s *Server) DocumentLink(ctx context.Context, params *protocol.DocumentLink
 		target := pathToURI(includePath)
 
 		links = append(links, protocol.DocumentLink{
-			Range:  *astRangeToProtocol(inc.Range),
+			Range:  astRangeToLSP(mapper, inc.Range),
 			Target: &target,
 		})
 	}

--- a/internal/server/ranges.go
+++ b/internal/server/ranges.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"os"
+
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+
+	"github.com/juev/hledger-lsp/internal/ast"
+	"github.com/juev/hledger-lsp/internal/lsputil"
+	"github.com/juev/hledger-lsp/internal/textutil"
+)
+
+// astRangeToLSP converts a parser range to an LSP range through byte offsets.
+//
+// Prefer it over astRangeToProtocol, which reports lexer columns as LSP
+// characters: the lexer counts columns in runes, while LSP counts UTF-16 code
+// units, so every range on a line containing an emoji comes out too short.
+// Offsets carry no such ambiguity.
+func astRangeToLSP(mapper *lsputil.PositionMapper, rng ast.Range) protocol.Range {
+	return protocol.Range{
+		Start: mapper.ByteToLSP(rng.Start.Offset),
+		End:   mapper.ByteToLSP(rng.End.Offset),
+	}
+}
+
+// documentSource returns the content of a journal, preferring unsaved editor
+// state over what is on disk. The result is normalized, so offsets taken from
+// a journal parsed out of it line up with a PositionMapper built on it.
+func (s *Server) documentSource(docURI uri.URI) (string, bool) {
+	if content, ok := s.GetDocument(docURI); ok {
+		return textutil.NormalizeLineEndings(content), true
+	}
+	content, err := os.ReadFile(uriToPath(docURI))
+	if err != nil {
+		return "", false
+	}
+	return textutil.NormalizeLineEndings(string(content)), true
+}
+
+// mapperFor builds a position mapper for a journal the server may not have
+// open. Returns nil when the file cannot be read.
+func (s *Server) mapperFor(docURI uri.URI) *lsputil.PositionMapper {
+	content, ok := s.documentSource(docURI)
+	if !ok {
+		return nil
+	}
+	return lsputil.NewPositionMapper(content)
+}
+
+// mapperCache hands out one position mapper per journal path for requests that
+// answer across an include tree, so a file is read and indexed at most once.
+type mapperCache struct {
+	load    func(path string) *lsputil.PositionMapper
+	mappers map[string]*lsputil.PositionMapper
+}
+
+func (s *Server) newMapperCache() *mapperCache {
+	return &mapperCache{
+		load:    func(path string) *lsputil.PositionMapper { return s.mapperFor(pathToURI(path)) },
+		mappers: make(map[string]*lsputil.PositionMapper),
+	}
+}
+
+// rangeIn converts an AST range that belongs to the journal at path. It falls
+// back to the column-based conversion when the file cannot be read, which is
+// off by one per surrogate pair but better than dropping the location.
+func (c *mapperCache) rangeIn(path string, rng ast.Range) protocol.Range {
+	if c == nil {
+		return *astRangeToProtocol(rng)
+	}
+	mapper, ok := c.mappers[path]
+	if !ok {
+		mapper = c.load(path)
+		c.mappers[path] = mapper
+	}
+	if mapper == nil {
+		return *astRangeToProtocol(rng)
+	}
+	return astRangeToLSP(mapper, rng)
+}

--- a/internal/server/ranges.go
+++ b/internal/server/ranges.go
@@ -79,3 +79,6 @@ func (c *mapperCache) rangeIn(path string, rng ast.Range) protocol.Range {
 	}
 	return astRangeToLSP(mapper, rng)
 }
+
+// rangePtr is a small convenience for fields that hold an optional range.
+func rangePtr(rng protocol.Range) *protocol.Range { return &rng }

--- a/internal/server/references.go
+++ b/internal/server/references.go
@@ -26,24 +26,24 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 	resolved := s.getWorkspaceResolved(params.TextDocument.URI)
 	currentPath := uriToPath(params.TextDocument.URI)
 
-	return findReferences(target, resolved, currentPath, journal, params.Context.IncludeDeclaration), nil
+	return findReferences(target, resolved, currentPath, journal, params.Context.IncludeDeclaration, s.newMapperCache()), nil
 }
 
-func findReferences(target *definitionTarget, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, includeDeclaration bool) []protocol.Location {
+func findReferences(target *definitionTarget, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, includeDeclaration bool, mappers *mapperCache) []protocol.Location {
 	switch target.context {
 	case DefContextAccount:
-		return findAccountReferences(target.name, resolved, currentPath, currentJournal, includeDeclaration)
+		return findAccountReferences(target.name, resolved, currentPath, currentJournal, includeDeclaration, mappers)
 	case DefContextCommodity:
-		return findCommodityReferences(target.name, resolved, currentPath, currentJournal, includeDeclaration)
+		return findCommodityReferences(target.name, resolved, currentPath, currentJournal, includeDeclaration, mappers)
 	case DefContextPayee:
 		// Payees don't have declarations (no directive), so includeDeclaration is ignored
-		return findPayeeReferences(target.name, resolved, currentPath, currentJournal)
+		return findPayeeReferences(target.name, resolved, currentPath, currentJournal, mappers)
 	default:
 		return nil
 	}
 }
 
-func findAccountReferences(name string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, includeDeclaration bool) []protocol.Location {
+func findAccountReferences(name string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, includeDeclaration bool, mappers *mapperCache) []protocol.Location {
 	journals := allJournalsWithPaths(resolved, currentPath, currentJournal)
 	var locations []protocol.Location
 
@@ -56,7 +56,7 @@ func findAccountReferences(name string, resolved *include.ResolvedJournal, curre
 					if ad.Account.Name == name {
 						locations = append(locations, protocol.Location{
 							URI:   pathToURI(filePath),
-							Range: *astRangeToProtocol(computeAccountRange(&ad.Account)),
+							Range: mappers.rangeIn(filePath, computeAccountRange(&ad.Account)),
 						})
 					}
 				}
@@ -70,7 +70,7 @@ func findAccountReferences(name string, resolved *include.ResolvedJournal, curre
 				if p.Account.Name == name {
 					locations = append(locations, protocol.Location{
 						URI:   pathToURI(filePath),
-						Range: *astRangeToProtocol(computeAccountRange(&p.Account)),
+						Range: mappers.rangeIn(filePath, computeAccountRange(&p.Account)),
 					})
 				}
 			}
@@ -80,7 +80,7 @@ func findAccountReferences(name string, resolved *include.ResolvedJournal, curre
 	return sortAndDedup(locations)
 }
 
-func findCommodityReferences(symbol string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, includeDeclaration bool) []protocol.Location {
+func findCommodityReferences(symbol string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, includeDeclaration bool, mappers *mapperCache) []protocol.Location {
 	journals := allJournalsWithPaths(resolved, currentPath, currentJournal)
 	var locations []protocol.Location
 
@@ -93,7 +93,7 @@ func findCommodityReferences(symbol string, resolved *include.ResolvedJournal, c
 					if cd.Commodity.Symbol == symbol {
 						locations = append(locations, protocol.Location{
 							URI:   pathToURI(filePath),
-							Range: *astRangeToProtocol(cd.Commodity.Range),
+							Range: mappers.rangeIn(filePath, cd.Commodity.Range),
 						})
 					}
 				}
@@ -107,7 +107,7 @@ func findCommodityReferences(symbol string, resolved *include.ResolvedJournal, c
 				if p.Amount != nil && p.Amount.Commodity.Symbol == symbol {
 					locations = append(locations, protocol.Location{
 						URI:   pathToURI(filePath),
-						Range: *astRangeToProtocol(p.Amount.Commodity.Range),
+						Range: mappers.rangeIn(filePath, p.Amount.Commodity.Range),
 					})
 				}
 			}
@@ -117,7 +117,7 @@ func findCommodityReferences(symbol string, resolved *include.ResolvedJournal, c
 	return sortAndDedup(locations)
 }
 
-func findPayeeReferences(payee string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal) []protocol.Location {
+func findPayeeReferences(payee string, resolved *include.ResolvedJournal, currentPath string, currentJournal *ast.Journal, mappers *mapperCache) []protocol.Location {
 	journals := allJournalsWithPaths(resolved, currentPath, currentJournal)
 	var locations []protocol.Location
 
@@ -130,7 +130,7 @@ func findPayeeReferences(payee string, resolved *include.ResolvedJournal, curren
 			if txPayee == payee {
 				locations = append(locations, protocol.Location{
 					URI:   pathToURI(filePath),
-					Range: *astRangeToProtocol(payeeRange(tx, payee)),
+					Range: mappers.rangeIn(filePath, payeeRange(tx, payee)),
 				})
 			}
 		}

--- a/internal/server/references.go
+++ b/internal/server/references.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/include"
+	"github.com/juev/hledger-lsp/internal/lsputil"
 )
 
 func (s *Server) References(ctx context.Context, params *protocol.ReferenceParams) ([]protocol.Location, error) {
@@ -18,7 +19,8 @@ func (s *Server) References(ctx context.Context, params *protocol.ReferenceParam
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 
-	target := findDefinitionTarget(journal, params.Position)
+	mapper := lsputil.NewPositionMapper(doc)
+	target := findDefinitionTarget(mapper, journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {
 		return nil, nil
 	}

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -7,6 +7,8 @@ import (
 
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
+
+	"github.com/juev/hledger-lsp/internal/lsputil"
 )
 
 func (s *Server) prepareRename(_ context.Context, params *protocol.PrepareRenameParams) (protocol.PrepareRenameResult, error) {
@@ -16,7 +18,7 @@ func (s *Server) prepareRename(_ context.Context, params *protocol.PrepareRename
 	}
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
-	target := findDefinitionTarget(journal, params.Position)
+	target := findDefinitionTarget(lsputil.NewPositionMapper(doc), journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {
 		return nil, nil
 	}
@@ -35,7 +37,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 	}
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
-	target := findDefinitionTarget(journal, params.Position)
+	target := findDefinitionTarget(lsputil.NewPositionMapper(doc), journal, params.Position)
 	if target == nil || target.context == DefContextUnknown {
 		return nil, nil
 	}

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -43,7 +43,7 @@ func (s *Server) Rename(ctx context.Context, params *protocol.RenameParams) (*pr
 	resolved := s.getWorkspaceResolved(params.TextDocument.URI)
 	currentPath := uriToPath(params.TextDocument.URI)
 
-	locations := findReferences(target, resolved, currentPath, journal, true)
+	locations := findReferences(target, resolved, currentPath, journal, true, s.newMapperCache())
 	if len(locations) == 0 {
 		return nil, nil
 	}

--- a/internal/server/selection_range.go
+++ b/internal/server/selection_range.go
@@ -17,12 +17,13 @@ func (s *Server) SelectionRange(_ context.Context, params *protocol.SelectionRan
 	}
 
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
+	mapper := lsputil.NewPositionMapper(doc)
 	lines := strings.Split(doc, "\n")
 	docRange := documentRange(lines)
 
 	result := make([]protocol.SelectionRange, len(params.Positions))
 	for i, pos := range params.Positions {
-		result[i] = buildSelectionRange(journal, pos, docRange)
+		result[i] = buildSelectionRange(mapper, journal, pos, docRange)
 	}
 
 	return result, nil
@@ -40,25 +41,25 @@ func documentRange(lines []string) protocol.Range {
 	}
 }
 
-func buildSelectionRange(journal *ast.Journal, pos protocol.Position, docRange protocol.Range) protocol.SelectionRange {
+func buildSelectionRange(mapper *lsputil.PositionMapper, journal *ast.Journal, pos protocol.Position, docRange protocol.Range) protocol.SelectionRange {
 	docSel := protocol.SelectionRange{Range: docRange}
 
 	for i := range journal.Transactions {
 		tx := &journal.Transactions[i]
-		txRange := *astRangeToProtocol(tx.Range)
+		txRange := astRangeToLSP(mapper, tx.Range)
 		if !rangeContainsPosition(txRange, pos) {
 			continue
 		}
 
 		txSel := protocol.SelectionRange{Range: txRange, Parent: &docSel}
 
-		if dateRange := *astRangeToProtocol(tx.Date.Range); rangeContainsPosition(dateRange, pos) {
+		if dateRange := astRangeToLSP(mapper, tx.Date.Range); rangeContainsPosition(dateRange, pos) {
 			return protocol.SelectionRange{Range: dateRange, Parent: &txSel}
 		}
 
 		payee := getPayeeOrDescription(tx)
 		if payee != "" {
-			payeeRange := *astRangeToProtocol(payeeRange(tx, payee))
+			payeeRange := astRangeToLSP(mapper, payeeRange(tx, payee))
 			if rangeContainsPosition(payeeRange, pos) {
 				return protocol.SelectionRange{Range: payeeRange, Parent: &txSel}
 			}
@@ -66,14 +67,14 @@ func buildSelectionRange(journal *ast.Journal, pos protocol.Position, docRange p
 
 		for j := range tx.Postings {
 			p := &tx.Postings[j]
-			postingRange := *astRangeToProtocol(p.Range)
+			postingRange := astRangeToLSP(mapper, p.Range)
 			if !rangeContainsPosition(postingRange, pos) {
 				continue
 			}
 
 			postingSel := protocol.SelectionRange{Range: postingRange, Parent: &txSel}
 
-			accountRange := *astRangeToProtocol(p.Account.Range)
+			accountRange := astRangeToLSP(mapper, p.Account.Range)
 			if rangeContainsPosition(accountRange, pos) {
 				segRange := findAccountSegmentRange(p.Account, pos)
 				if segRange != nil && !rangesEqual(*segRange, accountRange) {
@@ -84,10 +85,10 @@ func buildSelectionRange(journal *ast.Journal, pos protocol.Position, docRange p
 			}
 
 			if p.Amount != nil {
-				amountRange := *astRangeToProtocol(p.Amount.Range)
+				amountRange := astRangeToLSP(mapper, p.Amount.Range)
 				if rangeContainsPosition(amountRange, pos) {
 					amountSel := protocol.SelectionRange{Range: amountRange, Parent: &postingSel}
-					commodityRange := *astRangeToProtocol(p.Amount.Commodity.Range)
+					commodityRange := astRangeToLSP(mapper, p.Amount.Commodity.Range)
 					if p.Amount.Commodity.Symbol != "" && rangeContainsPosition(commodityRange, pos) {
 						return protocol.SelectionRange{Range: commodityRange, Parent: &amountSel}
 					}
@@ -102,7 +103,7 @@ func buildSelectionRange(journal *ast.Journal, pos protocol.Position, docRange p
 	}
 
 	for _, dir := range journal.Directives {
-		dirRange := *astRangeToProtocol(dir.GetRange())
+		dirRange := astRangeToLSP(mapper, dir.GetRange())
 		if !rangeContainsPosition(dirRange, pos) {
 			continue
 		}
@@ -111,12 +112,12 @@ func buildSelectionRange(journal *ast.Journal, pos protocol.Position, docRange p
 
 		switch d := dir.(type) {
 		case ast.AccountDirective:
-			accountRange := *astRangeToProtocol(ensureRangeEnd(d.Account.Range, d.Account.Name))
+			accountRange := astRangeToLSP(mapper, ensureRangeEnd(d.Account.Range, d.Account.Name))
 			if rangeContainsPosition(accountRange, pos) {
 				return protocol.SelectionRange{Range: accountRange, Parent: &dirSel}
 			}
 		case ast.CommodityDirective:
-			commodityRange := *astRangeToProtocol(ensureRangeEnd(d.Commodity.Range, d.Commodity.Symbol))
+			commodityRange := astRangeToLSP(mapper, ensureRangeEnd(d.Commodity.Range, d.Commodity.Symbol))
 			if rangeContainsPosition(commodityRange, pos) {
 				return protocol.SelectionRange{Range: commodityRange, Parent: &dirSel}
 			}
@@ -126,7 +127,7 @@ func buildSelectionRange(journal *ast.Journal, pos protocol.Position, docRange p
 	}
 
 	for _, comment := range journal.Comments {
-		commentRange := *astRangeToProtocol(comment.Range)
+		commentRange := astRangeToLSP(mapper, comment.Range)
 		if rangeContainsPosition(commentRange, pos) {
 			return protocol.SelectionRange{Range: commentRange, Parent: &docSel}
 		}

--- a/internal/server/semantic.go
+++ b/internal/server/semantic.go
@@ -337,8 +337,16 @@ type semanticToken struct {
 	modifiers uint32
 }
 
+// semanticCol converts a lexer position to the UTF-16 column LSP expects.
+// The lexer counts columns in runes, so a token that follows an emoji on the
+// same line would otherwise be reported one unit too far left.
+func semanticCol(mapper *lsputil.PositionMapper, pos parser.Position) uint32 {
+	return mapper.ByteToLSP(pos.Offset).Character
+}
+
 func tokenizeForSemantics(content string) []semanticToken {
 	lexer := parser.NewLexer(content)
+	mapper := lsputil.NewPositionMapper(content)
 	var tokens []semanticToken
 
 	inDirective := false
@@ -369,14 +377,14 @@ func tokenizeForSemantics(content string) []semanticToken {
 					inCommentBlock = false
 					tokens = append(tokens, semanticToken{
 						line:      uint32(tok.Pos.Line - 1),
-						col:       uint32(tok.Pos.Column - 1),
+						col:       semanticCol(mapper, tok.Pos),
 						length:    uint32(lsputil.UTF16Len(tok.Value)),
 						tokenType: TokenTypeDirective,
 						modifiers: 0,
 					})
 					tokens = append(tokens, semanticToken{
 						line:      uint32(next.Pos.Line - 1),
-						col:       uint32(next.Pos.Column - 1),
+						col:       semanticCol(mapper, next.Pos),
 						length:    uint32(lsputil.UTF16Len(next.Value)),
 						tokenType: TokenTypeDirective,
 						modifiers: 0,
@@ -386,7 +394,7 @@ func tokenizeForSemantics(content string) []semanticToken {
 				// Not "end comment" — emit "end" as comment, then handle next token
 				tokens = append(tokens, semanticToken{
 					line:      uint32(tok.Pos.Line - 1),
-					col:       uint32(tok.Pos.Column - 1),
+					col:       semanticCol(mapper, tok.Pos),
 					length:    uint32(lsputil.UTF16Len(tok.Value)),
 					tokenType: TokenTypeComment,
 					modifiers: 0,
@@ -408,7 +416,7 @@ func tokenizeForSemantics(content string) []semanticToken {
 			}
 			tokens = append(tokens, semanticToken{
 				line:      uint32(tok.Pos.Line - 1),
-				col:       uint32(tok.Pos.Column - 1),
+				col:       semanticCol(mapper, tok.Pos),
 				length:    length,
 				tokenType: TokenTypeComment,
 				modifiers: 0,
@@ -432,7 +440,7 @@ func tokenizeForSemantics(content string) []semanticToken {
 					// Emit "comment" directive token
 					tokens = append(tokens, semanticToken{
 						line:      uint32(tok.Pos.Line - 1),
-						col:       uint32(tok.Pos.Column - 1),
+						col:       semanticCol(mapper, tok.Pos),
 						length:    uint32(lsputil.UTF16Len(tok.Value)),
 						tokenType: TokenTypeDirective,
 						modifiers: 0,
@@ -457,14 +465,14 @@ func tokenizeForSemantics(content string) []semanticToken {
 				strings.TrimSpace(next.Value) == "comment" {
 				tokens = append(tokens, semanticToken{
 					line:      uint32(tok.Pos.Line - 1),
-					col:       uint32(tok.Pos.Column - 1),
+					col:       semanticCol(mapper, tok.Pos),
 					length:    uint32(lsputil.UTF16Len(tok.Value)),
 					tokenType: TokenTypeDirective,
 					modifiers: 0,
 				})
 				tokens = append(tokens, semanticToken{
 					line:      uint32(next.Pos.Line - 1),
-					col:       uint32(next.Pos.Column - 1),
+					col:       semanticCol(mapper, next.Pos),
 					length:    uint32(lsputil.UTF16Len(next.Value)),
 					tokenType: TokenTypeDirective,
 					modifiers: 0,
@@ -476,7 +484,7 @@ func tokenizeForSemantics(content string) []semanticToken {
 			if ok {
 				tokens = append(tokens, semanticToken{
 					line:      uint32(tok.Pos.Line - 1),
-					col:       uint32(tok.Pos.Column - 1),
+					col:       semanticCol(mapper, tok.Pos),
 					length:    uint32(lsputil.UTF16Len(tok.Value)),
 					tokenType: semType,
 					modifiers: 0,
@@ -514,7 +522,7 @@ func tokenizeForSemantics(content string) []semanticToken {
 				pendingNegative = true
 				tokens = append(tokens, semanticToken{
 					line:      uint32(tok.Pos.Line - 1),
-					col:       uint32(tok.Pos.Column - 1),
+					col:       semanticCol(mapper, tok.Pos),
 					length:    uint32(lsputil.UTF16Len(tok.Value)),
 					tokenType: TokenTypeAmount,
 					modifiers: 1 << ModifierNegative,
@@ -566,7 +574,7 @@ func tokenizeForSemantics(content string) []semanticToken {
 
 		// Handle comments with tags - extract tag tokens
 		if tok.Type == parser.TokenComment {
-			tagTokens := extractTagTokensFromComment(tok)
+			tagTokens := extractTagTokensFromComment(mapper, tok)
 			if len(tagTokens) > 0 {
 				tokens = append(tokens, tagTokens...)
 				continue
@@ -586,7 +594,7 @@ func tokenizeForSemantics(content string) []semanticToken {
 
 		tokens = append(tokens, semanticToken{
 			line:      uint32(tok.Pos.Line - 1),
-			col:       uint32(tok.Pos.Column - 1),
+			col:       semanticCol(mapper, tok.Pos),
 			length:    length,
 			tokenType: semType,
 			modifiers: modifiers,
@@ -596,14 +604,14 @@ func tokenizeForSemantics(content string) []semanticToken {
 	return tokens
 }
 
-func extractTagTokensFromComment(tok parser.Token) []semanticToken {
+func extractTagTokensFromComment(mapper *lsputil.PositionMapper, tok parser.Token) []semanticToken {
 	commentText := tok.Value
 	if !strings.Contains(commentText, ":") {
 		return nil
 	}
 
 	baseLine := uint32(tok.Pos.Line - 1)
-	baseCol := uint32(tok.Pos.Column - 1)
+	baseCol := semanticCol(mapper, tok.Pos)
 
 	// Tag/value spans are collected as UTF-16 offsets from the ';' marker.
 	// Offset 0 is the ';' itself; the comment text begins at offset 1.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/lsputil"
 	"github.com/juev/hledger-lsp/internal/rules"
+	"github.com/juev/hledger-lsp/internal/textutil"
 	"github.com/juev/hledger-lsp/internal/workspace"
 )
 
@@ -110,8 +111,11 @@ func (s *Server) SetClient(client protocol.Client) {
 	s.client = client
 }
 
+// StoreDocument records document content, normalizing line endings the same
+// way the didOpen/didChange handlers do. Everything downstream — AST offsets,
+// PositionMapper, the rope in internal/document — assumes LF-only text.
 func (s *Server) StoreDocument(uri uri.URI, content string) {
-	s.documents.Store(uri, content)
+	s.documents.Store(uri, textutil.NormalizeLineEndings(content))
 }
 
 func (s *Server) Initialize(ctx context.Context, params *protocol.InitializeParams) (*protocol.InitializeResult, error) {
@@ -294,7 +298,7 @@ func (s *Server) Exit(ctx context.Context) error {
 }
 
 func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
-	content := normalizeLineEndings(params.TextDocument.Text)
+	content := textutil.NormalizeLineEndings(params.TextDocument.Text)
 	s.documents.Store(params.TextDocument.URI, content)
 	s.alignmentCache.Delete(params.TextDocument.URI)
 	s.invalidateDocText(params.TextDocument.URI)
@@ -321,13 +325,13 @@ func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDo
 				if change == nil {
 					continue
 				}
-				content = normalizeLineEndings(change.Text)
+				content = textutil.NormalizeLineEndings(change.Text)
 				s.invalidateDocText(params.TextDocument.URI)
 			case *protocol.TextDocumentContentChangePartial:
 				if change == nil {
 					continue
 				}
-				content = s.applyChange(params.TextDocument.URI, content, change.Range, normalizeLineEndings(change.Text))
+				content = s.applyChange(params.TextDocument.URI, content, change.Range, textutil.NormalizeLineEndings(change.Text))
 			}
 		}
 		s.documents.Store(params.TextDocument.URI, content)
@@ -352,12 +356,6 @@ func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDo
 	return nil
 }
 
-func normalizeLineEndings(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.ReplaceAll(s, "\r", "\n")
-	return s
-}
-
 func syncKindPtr(value protocol.TextDocumentSyncKind) *protocol.TextDocumentSyncKind { return &value }
 
 func (s *Server) clearAlignmentCache() {
@@ -377,7 +375,7 @@ func (s *Server) DidClose(ctx context.Context, params *protocol.DidCloseTextDocu
 	if s.workspace != nil {
 		if path := uriToPath(params.TextDocument.URI); filetype.IsJournalPath(path) {
 			if data, err := os.ReadFile(path); err == nil {
-				s.workspace.UpdateFile(path, normalizeLineEndings(string(data)))
+				s.workspace.UpdateFile(path, textutil.NormalizeLineEndings(string(data)))
 				s.loader.InvalidateFile(path)
 			}
 		}
@@ -394,7 +392,7 @@ func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocume
 			if content, ok := s.GetDocument(params.TextDocument.URI); ok {
 				s.workspace.UpdateFile(path, content)
 			} else if data, err := os.ReadFile(path); err == nil {
-				s.workspace.UpdateFile(path, normalizeLineEndings(string(data)))
+				s.workspace.UpdateFile(path, textutil.NormalizeLineEndings(string(data)))
 			}
 			s.loader.InvalidateFile(path)
 		}
@@ -772,7 +770,7 @@ func (s *Server) DidChangeWatchedFiles(ctx context.Context, params *protocol.Did
 
 		if change.Type == protocol.FileChangeTypeChanged || change.Type == protocol.FileChangeTypeCreated {
 			if data, err := os.ReadFile(path); err == nil {
-				s.workspace.UpdateFile(path, normalizeLineEndings(string(data)))
+				s.workspace.UpdateFile(path, textutil.NormalizeLineEndings(string(data)))
 			}
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -549,14 +549,23 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI, content
 
 func (s *Server) analyze(docURI uri.URI, path, content string) []protocol.Diagnostic {
 	journal, parseErrs := s.cachedJournal(docURI, content)
-	mapper := lsputil.NewPositionMapper(content)
+
+	// Analysis runs on every keystroke, and indexing the document costs a pass
+	// over it, so pay for the mapper only when there is a range to convert.
+	var mapper *lsputil.PositionMapper
+	positionMapper := func() *lsputil.PositionMapper {
+		if mapper == nil {
+			mapper = lsputil.NewPositionMapper(content)
+		}
+		return mapper
+	}
 
 	diagnostics := make([]protocol.Diagnostic, 0, len(parseErrs))
 	for _, err := range parseErrs {
 		diagnostics = append(diagnostics, protocol.Diagnostic{
 			Range: protocol.Range{
-				Start: mapper.ByteToLSP(err.Pos.Offset),
-				End:   mapper.ByteToLSP(err.End.Offset),
+				Start: positionMapper().ByteToLSP(err.Pos.Offset),
+				End:   positionMapper().ByteToLSP(err.End.Offset),
 			},
 			Severity: protocol.DiagnosticSeverityError,
 			Source:   protocol.NewOptional("hledger-lsp"),
@@ -583,7 +592,7 @@ func (s *Server) analyze(docURI uri.URI, path, content string) []protocol.Diagno
 			continue
 		}
 		diagnostics = append(diagnostics, protocol.Diagnostic{
-			Range:    astRangeToLSP(mapper, diag.Range),
+			Range:    astRangeToLSP(positionMapper(), diag.Range),
 			Severity: toProtocolSeverity(diag.Severity),
 			Source:   protocol.NewOptional("hledger-lsp"),
 			Message:  protocol.String(diag.Message),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -205,6 +205,7 @@ func (s *Server) Initialize(ctx context.Context, params *protocol.InitializePara
 			caps.CodeActionProvider = &protocol.CodeActionOptions{
 				CodeActionKinds: []protocol.CodeActionKind{
 					protocol.CodeActionKindQuickFix,
+					insertInferredAmountKind,
 					"source.hledger",
 				},
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -549,19 +549,14 @@ func (s *Server) publishDiagnostics(ctx context.Context, docURI uri.URI, content
 
 func (s *Server) analyze(docURI uri.URI, path, content string) []protocol.Diagnostic {
 	journal, parseErrs := s.cachedJournal(docURI, content)
+	mapper := lsputil.NewPositionMapper(content)
 
 	diagnostics := make([]protocol.Diagnostic, 0, len(parseErrs))
 	for _, err := range parseErrs {
 		diagnostics = append(diagnostics, protocol.Diagnostic{
 			Range: protocol.Range{
-				Start: protocol.Position{
-					Line:      uint32(max(0, err.Pos.Line-1)),
-					Character: uint32(max(0, err.Pos.Column-1)),
-				},
-				End: protocol.Position{
-					Line:      uint32(max(0, err.End.Line-1)),
-					Character: uint32(max(0, err.End.Column-1)),
-				},
+				Start: mapper.ByteToLSP(err.Pos.Offset),
+				End:   mapper.ByteToLSP(err.End.Offset),
 			},
 			Severity: protocol.DiagnosticSeverityError,
 			Source:   protocol.NewOptional("hledger-lsp"),
@@ -588,7 +583,7 @@ func (s *Server) analyze(docURI uri.URI, path, content string) []protocol.Diagno
 			continue
 		}
 		diagnostics = append(diagnostics, protocol.Diagnostic{
-			Range:    *astRangeToProtocol(diag.Range),
+			Range:    astRangeToLSP(mapper, diag.Range),
 			Severity: toProtocolSeverity(diag.Severity),
 			Source:   protocol.NewOptional("hledger-lsp"),
 			Message:  protocol.String(diag.Message),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1457,50 +1457,15 @@ func TestServer_BalanceTolerance(t *testing.T) {
 	})
 }
 
-func TestNormalizeLineEndings(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "LF unchanged",
-			input:    "line1\nline2\nline3",
-			expected: "line1\nline2\nline3",
-		},
-		{
-			name:     "CRLF to LF",
-			input:    "line1\r\nline2\r\nline3",
-			expected: "line1\nline2\nline3",
-		},
-		{
-			name:     "bare CR to LF",
-			input:    "line1\rline2\rline3",
-			expected: "line1\nline2\nline3",
-		},
-		{
-			name:     "mixed line endings",
-			input:    "line1\r\nline2\nline3\rline4",
-			expected: "line1\nline2\nline3\nline4",
-		},
-		{
-			name:     "empty string",
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "no line endings",
-			input:    "hello",
-			expected: "hello",
-		},
-	}
+func TestServer_StoreDocument_NormalizesCRLF(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///test.journal")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeLineEndings(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+	srv.StoreDocument(docURI, "2024-01-15 test\r\n    expenses:food  $50\r\n    assets:cash\r")
+
+	doc, ok := srv.GetDocument(docURI)
+	require.True(t, ok)
+	assert.NotContains(t, doc, "\r", "every write into the document map must land LF-only")
 }
 
 func TestServer_DidOpen_NormalizesCRLF(t *testing.T) {
@@ -1558,7 +1523,7 @@ func TestServer_Format_CRLFDocumentNoBlankLines(t *testing.T) {
 	uri := uri.URI("file:///test.journal")
 	content := "2024-01-15 购买基金\r\n    资产:微信wx  $50  ;date:2026-02-21\r\n    资产:待报销费用bx\r\n"
 
-	srv.documents.Store(uri, normalizeLineEndings(content))
+	srv.StoreDocument(uri, content)
 
 	params := &protocol.DocumentFormattingParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},

--- a/internal/server/symbol.go
+++ b/internal/server/symbol.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/filetype"
+	"github.com/juev/hledger-lsp/internal/lsputil"
 	"github.com/juev/hledger-lsp/internal/rules"
 )
 
@@ -31,22 +32,23 @@ func (s *Server) documentSymbols(
 		return nil
 	}
 
+	mapper := lsputil.NewPositionMapper(doc)
 	symbols := make([]protocol.DocumentSymbol, 0, len(journal.Transactions)+len(journal.Directives)+len(journal.Includes))
 
-	symbols = append(symbols, groupTransactionsByMonth(journal.Transactions)...)
+	symbols = append(symbols, groupTransactionsByMonth(mapper, journal.Transactions)...)
 
 	for _, dir := range journal.Directives {
-		symbols = append(symbols, directiveToSymbol(dir))
+		symbols = append(symbols, directiveToSymbol(mapper, dir))
 	}
 
 	for _, inc := range journal.Includes {
-		symbols = append(symbols, includeToSymbol(inc))
+		symbols = append(symbols, includeToSymbol(mapper, inc))
 	}
 
 	return symbols
 }
 
-func groupTransactionsByMonth(transactions []ast.Transaction) []protocol.DocumentSymbol {
+func groupTransactionsByMonth(mapper *lsputil.PositionMapper, transactions []ast.Transaction) []protocol.DocumentSymbol {
 	if len(transactions) == 0 {
 		return nil
 	}
@@ -70,7 +72,7 @@ func groupTransactionsByMonth(transactions []ast.Transaction) []protocol.Documen
 			order = append(order, key)
 		}
 		g.last = tx
-		g.children = append(g.children, transactionToSymbol(tx))
+		g.children = append(g.children, transactionToSymbol(mapper, tx))
 	}
 
 	sort.Strings(order)
@@ -78,7 +80,7 @@ func groupTransactionsByMonth(transactions []ast.Transaction) []protocol.Documen
 	result := make([]protocol.DocumentSymbol, 0, len(order))
 	for _, key := range order {
 		g := groups[key]
-		rng := *astRangeToProtocol(ast.Range{
+		rng := astRangeToLSP(mapper, ast.Range{
 			Start: g.first.Range.Start,
 			End:   g.last.Range.End,
 		})
@@ -93,8 +95,8 @@ func groupTransactionsByMonth(transactions []ast.Transaction) []protocol.Documen
 	return result
 }
 
-func includeToSymbol(inc ast.Include) protocol.DocumentSymbol {
-	rng := *astRangeToProtocol(inc.Range)
+func includeToSymbol(mapper *lsputil.PositionMapper, inc ast.Include) protocol.DocumentSymbol {
+	rng := astRangeToLSP(mapper, inc.Range)
 	return protocol.DocumentSymbol{
 		Name:           "include " + inc.Path,
 		Kind:           protocol.SymbolKindModule,
@@ -103,9 +105,9 @@ func includeToSymbol(inc ast.Include) protocol.DocumentSymbol {
 	}
 }
 
-func transactionToSymbol(tx ast.Transaction) protocol.DocumentSymbol {
+func transactionToSymbol(mapper *lsputil.PositionMapper, tx ast.Transaction) protocol.DocumentSymbol {
 	name := formatTransactionName(tx)
-	rng := *astRangeToProtocol(tx.Range)
+	rng := astRangeToLSP(mapper, tx.Range)
 
 	return protocol.DocumentSymbol{
 		Name:           name,
@@ -123,7 +125,7 @@ func formatTransactionName(tx ast.Transaction) string {
 	return date
 }
 
-func directiveToSymbol(dir ast.Directive) protocol.DocumentSymbol {
+func directiveToSymbol(mapper *lsputil.PositionMapper, dir ast.Directive) protocol.DocumentSymbol {
 	var name string
 	var kind protocol.SymbolKind
 
@@ -146,7 +148,7 @@ func directiveToSymbol(dir ast.Directive) protocol.DocumentSymbol {
 		kind = protocol.SymbolKindVariable
 	}
 
-	rng := *astRangeToProtocol(dir.GetRange())
+	rng := astRangeToLSP(mapper, dir.GetRange())
 	return protocol.DocumentSymbol{
 		Name:           name,
 		Kind:           kind,

--- a/internal/server/type_hierarchy.go
+++ b/internal/server/type_hierarchy.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"os"
 	"sort"
 	"strings"
 
@@ -224,7 +223,7 @@ func (s *Server) typeHierarchyCandidates(origin uri.URI, rootPath string) []type
 		}
 		mapper := mappers[docURI]
 		if mapper == nil {
-			content, ok := s.typeHierarchySource(docURI)
+			content, ok := s.documentSource(docURI)
 			if !ok {
 				continue
 			}
@@ -241,17 +240,6 @@ func (s *Server) typeHierarchyCandidates(origin uri.URI, rootPath string) []type
 		}
 	}
 	return candidates
-}
-
-func (s *Server) typeHierarchySource(docURI uri.URI) (string, bool) {
-	if content, ok := s.GetDocument(docURI); ok {
-		return textutil.NormalizeLineEndings(content), true
-	}
-	content, err := os.ReadFile(uriToPath(docURI))
-	if err != nil {
-		return "", false
-	}
-	return textutil.NormalizeLineEndings(string(content)), true
 }
 
 func (s *Server) typeHierarchyItem(candidate typeHierarchyCandidate, origin uri.URI, rootPath string) protocol.TypeHierarchyItem {

--- a/internal/server/type_hierarchy.go
+++ b/internal/server/type_hierarchy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/lsputil"
+	"github.com/juev/hledger-lsp/internal/textutil"
 )
 
 type typeHierarchyData struct {
@@ -45,7 +46,7 @@ func (s *Server) prepareTypeHierarchy(_ context.Context, params *protocol.TypeHi
 	if !ok {
 		return nil, nil
 	}
-	doc = normalizeLineEndings(doc)
+	doc = textutil.NormalizeLineEndings(doc)
 	journal, _ := s.cachedJournal(params.TextDocument.URI, doc)
 	mapper := lsputil.NewPositionMapper(doc)
 	for _, account := range hierarchyAccounts(journal) {
@@ -207,7 +208,7 @@ func (s *Server) typeHierarchyCandidates(origin uri.URI, rootPath string) []type
 			}
 		}
 	} else if doc, ok := s.GetDocument(origin); ok {
-		journal, _ := s.cachedJournal(origin, normalizeLineEndings(doc))
+		journal, _ := s.cachedJournal(origin, textutil.NormalizeLineEndings(doc))
 		occurrences = append(occurrences, include.JournalOccurrence{Path: uriToPath(origin), Journal: journal})
 	}
 
@@ -244,13 +245,13 @@ func (s *Server) typeHierarchyCandidates(origin uri.URI, rootPath string) []type
 
 func (s *Server) typeHierarchySource(docURI uri.URI) (string, bool) {
 	if content, ok := s.GetDocument(docURI); ok {
-		return normalizeLineEndings(content), true
+		return textutil.NormalizeLineEndings(content), true
 	}
 	content, err := os.ReadFile(uriToPath(docURI))
 	if err != nil {
 		return "", false
 	}
-	return normalizeLineEndings(string(content)), true
+	return textutil.NormalizeLineEndings(string(content)), true
 }
 
 func (s *Server) typeHierarchyItem(candidate typeHierarchyCandidate, origin uri.URI, rootPath string) protocol.TypeHierarchyItem {

--- a/internal/server/utf16_ranges_test.go
+++ b/internal/server/utf16_ranges_test.go
@@ -50,6 +50,47 @@ func TestReferences_ReportsUTF16RangesForEmojiAccount(t *testing.T) {
 	}
 }
 
+func TestDocumentHighlight_ReportsUTF16RangesForEmojiAccount(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///emoji.journal")
+	srv.StoreDocument(docURI, emojiAccountJournal)
+
+	highlights, err := srv.DocumentHighlight(context.Background(), &protocol.DocumentHighlightParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+			Position:     protocol.Position{Line: 3, Character: 6},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, highlights)
+
+	for _, highlight := range highlights {
+		if highlight.Range.Start.Line == 3 {
+			assert.Equal(t, uint32(emojiAccountStartChar), highlight.Range.Start.Character)
+			assert.Equal(t, uint32(emojiAccountEndChar), highlight.Range.End.Character)
+		}
+	}
+}
+
+func TestPrepareRename_ReportsUTF16RangeForEmojiAccount(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///emoji.journal")
+	srv.StoreDocument(docURI, emojiAccountJournal)
+
+	result, err := srv.prepareRename(context.Background(), &protocol.PrepareRenameParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+			Position:     protocol.Position{Line: 3, Character: 6},
+		},
+	})
+	require.NoError(t, err)
+
+	rng, ok := result.(*protocol.Range)
+	require.True(t, ok, "prepareRename should answer with a range, got %T", result)
+	assert.Equal(t, uint32(emojiAccountStartChar), rng.Start.Character)
+	assert.Equal(t, uint32(emojiAccountEndChar), rng.End.Character)
+}
+
 func TestDiagnostics_ReportUTF16RangesForEmojiAccount(t *testing.T) {
 	ts := newTestServer()
 	ts.cliClient = nil

--- a/internal/server/utf16_ranges_test.go
+++ b/internal/server/utf16_ranges_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+// A journal whose account name carries an emoji: "Расходы:🍜" is 9 runes but
+// 10 UTF-16 code units, so a range reported in lexer columns ends one unit
+// short of where the editor puts the account.
+const emojiAccountJournal = "account Расходы:🍜\n\n2024-01-01 обед\n    Расходы:🍜  $10\n    Активы:Наличные\n"
+
+const (
+	emojiAccountStartChar = 4                       // four spaces of indent
+	emojiAccountEndChar   = 4 + 8 + 2               // indent + "Расходы:" + the emoji as a surrogate pair
+	emojiDeclEndChar      = len("account ") + 8 + 2 //nolint:gocritic // same account on the directive line
+)
+
+func TestReferences_ReportsUTF16RangesForEmojiAccount(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///emoji.journal")
+	srv.StoreDocument(docURI, emojiAccountJournal)
+
+	result, err := srv.References(context.Background(), &protocol.ReferenceParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+			Position:     protocol.Position{Line: 3, Character: 6},
+		},
+		Context: protocol.ReferenceContext{IncludeDeclaration: true},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	for _, location := range result {
+		switch location.Range.Start.Line {
+		case 0:
+			assert.Equal(t, uint32(len("account ")), location.Range.Start.Character)
+			assert.Equal(t, uint32(emojiDeclEndChar), location.Range.End.Character)
+		case 3:
+			assert.Equal(t, uint32(emojiAccountStartChar), location.Range.Start.Character)
+			assert.Equal(t, uint32(emojiAccountEndChar), location.Range.End.Character)
+		default:
+			t.Fatalf("unexpected reference on line %d", location.Range.Start.Line)
+		}
+	}
+}
+
+func TestDiagnostics_ReportUTF16RangesForEmojiAccount(t *testing.T) {
+	ts := newTestServer()
+	ts.cliClient = nil
+	docURI := uri.URI("file:///emoji.journal")
+	// The undeclared account sits behind an emoji, so its column in runes and
+	// its column in UTF-16 code units differ.
+	content := "account Активы:Наличные\n\n2024-01-01 обед\n    Расходы:🍜  $10\n    Активы:Наличные\n"
+
+	diagnostics, err := ts.openAndWait(docURI, content)
+	require.NoError(t, err)
+
+	diag := requireDiagnosticByCode(t, diagnostics, "UNDECLARED_ACCOUNT")
+	assert.Equal(t, uint32(3), diag.Range.Start.Line)
+	assert.Equal(t, uint32(emojiAccountStartChar), diag.Range.Start.Character)
+	assert.Equal(t, uint32(emojiAccountEndChar), diag.Range.End.Character)
+}

--- a/internal/server/utf16_ranges_test.go
+++ b/internal/server/utf16_ranges_test.go
@@ -91,6 +91,37 @@ func TestPrepareRename_ReportsUTF16RangeForEmojiAccount(t *testing.T) {
 	assert.Equal(t, uint32(emojiAccountEndChar), rng.End.Character)
 }
 
+func TestSemanticTokens_ReportUTF16ColumnsAfterEmoji(t *testing.T) {
+	srv := NewServer()
+	docURI := uri.URI("file:///emoji.journal")
+	srv.StoreDocument(docURI, "2024-01-01 обед\n    Расходы:🍜  $10\n")
+
+	result, err := srv.SemanticTokensFull(context.Background(), &protocol.SemanticTokensParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: docURI},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Data)
+
+	// Decode the delta encoding into absolute columns for line 1.
+	var columns []uint32
+	line, col := uint32(0), uint32(0)
+	for i := 0; i+4 < len(result.Data); i += 5 {
+		if deltaLine := result.Data[i]; deltaLine > 0 {
+			line += deltaLine
+			col = result.Data[i+1]
+		} else {
+			col += result.Data[i+1]
+		}
+		if line == 1 {
+			columns = append(columns, col)
+		}
+	}
+
+	// "    Расходы:🍜" occupies 14 UTF-16 units, then two spaces, so the amount
+	// starts at 16 — one further right than the emoji's single rune suggests.
+	assert.Equal(t, []uint32{4, 16, 17}, columns, "account, commodity and number columns")
+}
+
 func TestDiagnostics_ReportUTF16RangesForEmojiAccount(t *testing.T) {
 	ts := newTestServer()
 	ts.cliClient = nil

--- a/internal/server/workspace_symbol.go
+++ b/internal/server/workspace_symbol.go
@@ -21,10 +21,11 @@ func (s *Server) WorkspaceSymbol(ctx context.Context, params *protocol.Workspace
 		startChar uint32
 	}
 	seen := make(map[symbolKey]bool)
+	mappers := s.newMapperCache()
 	var symbols []protocol.SymbolInformation
 
 	addSymbols := func(journal *ast.Journal, docURI uri.URI) {
-		for _, sym := range extractSymbols(journal, docURI, query) {
+		for _, sym := range extractSymbols(mappers, journal, docURI, query) {
 			key := symbolKey{
 				name:      sym.Name,
 				kind:      sym.Kind,
@@ -74,7 +75,7 @@ func (s *Server) WorkspaceSymbol(ctx context.Context, params *protocol.Workspace
 	return symbols, nil
 }
 
-func extractSymbols(journal *ast.Journal, uri uri.URI, query string) []protocol.SymbolInformation {
+func extractSymbols(mappers *mapperCache, journal *ast.Journal, uri uri.URI, query string) []protocol.SymbolInformation {
 	var symbols []protocol.SymbolInformation
 
 	for _, dir := range journal.Directives {
@@ -85,7 +86,7 @@ func extractSymbols(journal *ast.Journal, uri uri.URI, query string) []protocol.
 					BaseSymbolInformation: protocol.BaseSymbolInformation{Name: d.Account.Name, Kind: protocol.SymbolKindClass},
 					Location: protocol.Location{
 						URI:   uri,
-						Range: *astRangeToProtocol(d.Account.Range),
+						Range: mappers.rangeIn(uriToPath(uri), d.Account.Range),
 					},
 				})
 			}
@@ -95,7 +96,7 @@ func extractSymbols(journal *ast.Journal, uri uri.URI, query string) []protocol.
 					BaseSymbolInformation: protocol.BaseSymbolInformation{Name: d.Commodity.Symbol, Kind: protocol.SymbolKindEnum},
 					Location: protocol.Location{
 						URI:   uri,
-						Range: *astRangeToProtocol(d.Commodity.Range),
+						Range: mappers.rangeIn(uriToPath(uri), d.Commodity.Range),
 					},
 				})
 			}
@@ -113,7 +114,7 @@ func extractSymbols(journal *ast.Journal, uri uri.URI, query string) []protocol.
 					BaseSymbolInformation: protocol.BaseSymbolInformation{Name: payee, Kind: protocol.SymbolKindFunction},
 					Location: protocol.Location{
 						URI:   uri,
-						Range: *astRangeToProtocol(payeeRange(tx, payee)),
+						Range: mappers.rangeIn(uriToPath(uri), payeeRange(tx, payee)),
 					},
 				})
 			}

--- a/internal/textutil/textutil.go
+++ b/internal/textutil/textutil.go
@@ -1,0 +1,16 @@
+// Package textutil holds text helpers shared by every layer that accepts
+// journal or rules content, without depending on any of them.
+package textutil
+
+import "strings"
+
+// NormalizeLineEndings converts CRLF and bare CR to LF.
+//
+// Every document the server keeps in memory is normalized on the way in, and
+// the rest of the server relies on it: AST offsets, PositionMapper and the
+// rope in internal/document all assume LF-only text, so a single unnormalized
+// entry point would silently shift positions.
+func NormalizeLineEndings(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\r", "\n")
+}

--- a/internal/textutil/textutil_test.go
+++ b/internal/textutil/textutil_test.go
@@ -1,0 +1,29 @@
+package textutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeLineEndings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "LF unchanged", input: "line1\nline2\nline3", expected: "line1\nline2\nline3"},
+		{name: "CRLF to LF", input: "line1\r\nline2\r\nline3", expected: "line1\nline2\nline3"},
+		{name: "bare CR to LF", input: "line1\rline2\rline3", expected: "line1\nline2\nline3"},
+		{name: "mixed line endings", input: "line1\r\nline2\nline3\rline4", expected: "line1\nline2\nline3\nline4"},
+		{name: "trailing CR", input: "line1\r", expected: "line1\n"},
+		{name: "empty string", input: "", expected: ""},
+		{name: "no line endings", input: "hello", expected: "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NormalizeLineEndings(tt.input))
+		})
+	}
+}

--- a/internal/workspace/index.go
+++ b/internal/workspace/index.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juev/hledger-lsp/internal/ast"
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/parser"
+	"github.com/juev/hledger-lsp/internal/textutil"
 )
 
 type TransactionEntry struct {
@@ -349,7 +350,7 @@ func copyNestedIntMap(source map[string]map[string]int) map[string]map[string]in
 }
 
 func BuildFileIndexFromContent(path, content string) (*FileIndex, *ast.Journal, []string) {
-	journal, parseErrs := parser.Parse(normalizeLineEndings(content))
+	journal, parseErrs := parser.Parse(textutil.NormalizeLineEndings(content))
 	var errors []string
 	for _, err := range parseErrs {
 		errors = append(errors, err.Message)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/juev/hledger-lsp/internal/ast"
@@ -14,15 +13,8 @@ import (
 	"github.com/juev/hledger-lsp/internal/formatter"
 	"github.com/juev/hledger-lsp/internal/include"
 	"github.com/juev/hledger-lsp/internal/parser"
+	"github.com/juev/hledger-lsp/internal/textutil"
 )
-
-// normalizeLineEndings converts \r\n and \r to \n.
-// The parser assumes \n-only input. Files read from disk on Windows may have CRLF.
-func normalizeLineEndings(s string) string {
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.ReplaceAll(s, "\r", "\n")
-	return s
-}
 
 // IncludeTree represents a single include tree rooted at one journal file.
 // Each root file (file with no incoming include edges) gets its own tree
@@ -186,7 +178,7 @@ func (w *Workspace) buildIncludeGraph(files []string) {
 			continue
 		}
 
-		journal, errs := parser.Parse(normalizeLineEndings(string(content)))
+		journal, errs := parser.Parse(textutil.NormalizeLineEndings(string(content)))
 		if len(errs) > 0 {
 			for _, e := range errs {
 				w.parseErrors = append(w.parseErrors, fmt.Sprintf("%s: %s", file, e.Message))
@@ -395,7 +387,7 @@ func (w *Workspace) UpdateFile(path, content string) {
 	if path == "" || !filetype.IsJournalPath(path) {
 		return
 	}
-	journal, _ := parser.Parse(normalizeLineEndings(content))
+	journal, _ := parser.Parse(textutil.NormalizeLineEndings(content))
 	w.UpdateFileWithJournal(path, content, journal)
 }
 
@@ -446,7 +438,7 @@ func (w *Workspace) UpdateFileWithJournal(path, content string, journal *ast.Jou
 		tree.LoadErrors = errs
 		tree.rootContentSnapshotIsValid = rootPath == path
 		if tree.rootContentSnapshotIsValid {
-			tree.rootContentSnapshot = normalizeLineEndings(content)
+			tree.rootContentSnapshot = textutil.NormalizeLineEndings(content)
 		}
 		tree.clearCaches()
 		w.syncOwnershipFromResolvedLocked(tree)


### PR DESCRIPTION
Fixes the server side of juev/hledger-vscode#245, plus three defects found along the way.

## Inferred amount hints no longer shift the cursor

The inferred-amount inlay hint was anchored right after the account name. An inlay hint takes up room in the rendered line, so it pushed the alignment padding — and the cursor waiting at the amount column after Tab — to the right, which made Tab alignment look broken.

The hint is now anchored past the end of the posting line, so nothing to its left moves.

## New code action: insert the inferred amount

`quickfix.hledger.insertInferredAmount` writes the amount hledger infers for an amountless posting into the document, aligned to the document's amount column and formatted like its sibling postings (`20.50 USD`, not `20.5 USD`). It is driven by posting effects rather than a diagnostic, because a transaction with an inferred amount is perfectly valid, and it stays available regardless of the inlay hint settings so clients can bind it to a key.

## `CodeActionContext.Only` is honoured

The server returned every action regardless of the requested kinds. A client asking for one specific kind also got the five `source.hledger` entries back, and paid for a full document analysis it had not asked for. Filtering follows the dotted kind hierarchy from the spec, so `quickfix` still selects `quickfix.hledger.insertInferredAmount`, and each action source is skipped before it runs when the filter rules its kind out.

## Line endings are normalized in one place

Five identical copies of `normalizeLineEndings` plus a sixth, narrower one inside the parser, which stripped CRLF but not a bare CR. The parser copy was the harmful one: AST offsets index the exact string handed to `Parse`, and callers map those offsets back to LSP positions against that same string, so normalizing inside the parser gave the AST a coordinate system of its own. Nothing in production hit that path, but nothing enforced it either — `StoreDocument` was the one write into the document map that bypassed normalization.

The helper now lives in `internal/textutil`, the parser documents an LF contract instead of silently repairing its input, and `StoreDocument` normalizes.

## LSP columns are UTF-16, not runes

The lexer counts columns in runes, LSP counts them in UTF-16 code units, and `astRangeToProtocol` handed the former straight to the client. On a line holding an emoji every range came out one unit short per surrogate pair — reproduced for diagnostics, references and semantic tokens before fixing.

Ranges now go through byte offsets and a `PositionMapper`, the recipe `hierarchyRange` already used. Requests that answer across an include tree share one mapper per file. Two of these mattered beyond the reported range: `findDefinitionTarget` hit-tests the cursor against symbol ranges, so it could resolve the wrong symbol; and the transaction lookup behind the unbalanced code lens compares a range the server itself emits.

Two smaller defects surfaced with it: account directives left the end of their range unset, so references reported a declaration ending at character 0; and `ensureRangeEnd` measured its synthetic end column in UTF-16 units inside a rune-counted field.

Rules-file ranges and the segment arithmetic in `findAccountSegmentRange` still use the column-based conversion — they come from a separate lexer with its own coordinate handling and need their own check first.

## Verification

`make test` and `make lint` pass after every commit. Diagnostics build their position mapper lazily, since analysis runs per keystroke and a clean document has no range to convert; the per-keystroke NFR test passes under a full parallel test run.

Checked against a built binary over the wire: in a CRLF document the hint position and the code action edit match the LF case; `only: ["quickfix.hledger.insertInferredAmount"]` returns exactly that one action where an unfiltered request returns both kinds; a reference on `    Расходы:🍜  $10` reports `[4, 14]`.
