### PR TITLE
fix(completion): offer payees after a status mark

### DIFF
--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -386,6 +386,42 @@ func indexFirstWhitespace(s string) int {
 	return -1
 }
 
+// payeeStartOffset returns the byte offset where the payee text of a transaction
+// header begins, skipping the date, an optional status mark and an optional
+// transaction code (hledger: DATE [STATUS] [(CODE)] DESCRIPTION). Only the bytes
+// before byteCol are inspected, so a header the user is still typing works too:
+// an unterminated code is left in place, because the cursor is still inside it.
+func payeeStartOffset(line string, byteCol int) int {
+	if byteCol > len(line) {
+		byteCol = len(line)
+	}
+	head := line[:byteCol]
+
+	wsIdx := indexFirstWhitespace(head)
+	if wsIdx == -1 {
+		return byteCol
+	}
+
+	start := skipSpacesAndTabs(head, wsIdx+1)
+	if start < len(head) && (head[start] == '*' || head[start] == '!') {
+		start = skipSpacesAndTabs(head, start+1)
+	}
+	if start < len(head) && head[start] == '(' {
+		if closeIdx := strings.IndexByte(head[start:], ')'); closeIdx != -1 {
+			start = skipSpacesAndTabs(head, start+closeIdx+1)
+		}
+	}
+
+	return start
+}
+
+func skipSpacesAndTabs(s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	return i
+}
+
 func isDigitOrSign(c byte) bool {
 	return (c >= '0' && c <= '9') || c == '-' || c == '+'
 }
@@ -846,13 +882,7 @@ func calculateTextEditRange(content string, pos protocol.Position, ctxType Compl
 			startByte = findCommodityStart(line, byteCol)
 		}
 	case ContextPayee:
-		wsIdx := indexFirstWhitespace(line[:byteCol])
-		if wsIdx != -1 {
-			startByte = wsIdx + 1
-			for startByte < byteCol && (line[startByte] == ' ' || line[startByte] == '\t' || line[startByte] == '*' || line[startByte] == '!') {
-				startByte++
-			}
-		}
+		startByte = payeeStartOffset(line, byteCol)
 	case ContextTagName:
 		info, ok := parseCommentCursor(line, byteCol)
 		if !ok {
@@ -1001,11 +1031,7 @@ func extractQueryText(content string, pos protocol.Position, ctxType CompletionC
 		return trimmed
 
 	case ContextPayee:
-		wsIdx := indexFirstWhitespace(beforeCursor)
-		if wsIdx == -1 {
-			return ""
-		}
-		return strings.TrimLeft(beforeCursor[wsIdx+1:], " \t")
+		return beforeCursor[payeeStartOffset(line, byteCol):]
 
 	case ContextCommodity:
 		if after, found := strings.CutPrefix(beforeCursor, directiveCommodity); found {

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -1446,6 +1446,13 @@ func TestExtractQueryText_Payee(t *testing.T) {
 			char:     18,
 			expected: "* Groc",
 		},
+		{
+			name:     "several spaces around status mark",
+			content:  "2024-01-15    *    Groc",
+			line:     0,
+			char:     23,
+			expected: "Groc",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2743,6 +2750,8 @@ func TestCompletion_PayeeAfterStatusMark(t *testing.T) {
 		{"status without space", "2024-01-17 *Groc", 16, 12},
 		{"status and transaction code", "2024-01-17 * (CHK1) ", 20, 20},
 		{"transaction code only", "2024-01-17 (INV-1) Groc", 23, 19},
+		{"spaces around status mark", "2024-01-17    *    ", 19, 19},
+		{"spaces around status mark with prefix", "2024-01-17    *    Groc", 23, 19},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -1362,6 +1362,90 @@ func TestExtractQueryText_Payee(t *testing.T) {
 			char:     11,
 			expected: "",
 		},
+		{
+			name:     "after cleared status mark",
+			content:  "2024-01-15 * ",
+			line:     0,
+			char:     13,
+			expected: "",
+		},
+		{
+			name:     "partial payee after pending status mark",
+			content:  "2024-01-15 ! Groc",
+			line:     0,
+			char:     17,
+			expected: "Groc",
+		},
+		{
+			name:     "status mark not followed by space",
+			content:  "2024-01-15 *Groc",
+			line:     0,
+			char:     16,
+			expected: "Groc",
+		},
+		{
+			name:     "cursor right after status mark",
+			content:  "2024-01-15 *",
+			line:     0,
+			char:     12,
+			expected: "",
+		},
+		{
+			name:     "cursor before status mark",
+			content:  "2024-01-15 * Groc",
+			line:     0,
+			char:     11,
+			expected: "",
+		},
+		{
+			name:     "status mark and transaction code",
+			content:  "2024-01-15 * (CHK1) Groc",
+			line:     0,
+			char:     24,
+			expected: "Groc",
+		},
+		{
+			name:     "transaction code without status mark",
+			content:  "2024-01-15 (INV-1) Groc",
+			line:     0,
+			char:     23,
+			expected: "Groc",
+		},
+		{
+			name:     "unclosed transaction code",
+			content:  "2024-01-15 * (CH",
+			line:     0,
+			char:     16,
+			expected: "(CH",
+		},
+		{
+			name:     "secondary date with status mark",
+			content:  "2024-01-15=2024-01-20 * Groc",
+			line:     0,
+			char:     28,
+			expected: "Groc",
+		},
+		{
+			name:     "cyrillic payee after status mark",
+			content:  "2024-01-15 * Пятёроч",
+			line:     0,
+			char:     20,
+			expected: "Пятёроч",
+		},
+		{
+			name:     "cjk payee after status mark",
+			content:  "2024-01-15 * 食料品店",
+			line:     0,
+			char:     17,
+			expected: "食料品店",
+		},
+		{
+			name:     "only one status mark skipped",
+			content:  "2024-01-15 ** Groc",
+			line:     0,
+			char:     18,
+			expected: "* Groc",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2644,6 +2728,79 @@ func TestCompletion_PayeeWithTab(t *testing.T) {
 	}
 }
 
+func TestCompletion_PayeeAfterStatusMark(t *testing.T) {
+	const history = "2024-01-15 Grocery Store\n    expenses:food  $50\n    assets:cash\n\n"
+
+	tests := []struct {
+		name      string
+		header    string
+		char      uint32
+		wantStart uint32
+	}{
+		{"cleared status", "2024-01-17 * ", 13, 13},
+		{"pending status", "2024-01-17 ! ", 13, 13},
+		{"status with partial payee", "2024-01-17 * Groc", 17, 13},
+		{"status without space", "2024-01-17 *Groc", 16, 12},
+		{"status and transaction code", "2024-01-17 * (CHK1) ", 20, 20},
+		{"transaction code only", "2024-01-17 (INV-1) Groc", 23, 19},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewServer()
+			srv.StoreDocument(uri.URI("file:///test.journal"), history+tt.header)
+
+			params := &protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{
+						URI: "file:///test.journal",
+					},
+					Position: protocol.Position{Line: 4, Character: tt.char},
+				},
+			}
+
+			result, err := srv.completion(context.Background(), params)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			labels := extractLabels(result.Items)
+			require.Contains(t, labels, "Grocery Store", "status mark must not suppress payee completion")
+
+			for _, item := range result.Items {
+				if item.Label != "Grocery Store" {
+					continue
+				}
+				edit := completionTextEdit(item)
+				require.NotNil(t, edit, "TextEdit should be set")
+				assert.Equal(t, tt.wantStart, edit.Range.Start.Character, "TextEdit should start at the payee")
+				assert.Equal(t, tt.char, edit.Range.End.Character, "TextEdit should end at cursor")
+			}
+		})
+	}
+}
+
+func TestCompletion_PayeeAfterStatusMarkCRLF(t *testing.T) {
+	srv := NewServer()
+	content := "2024-01-15 Grocery Store\r\n    expenses:food  $50\r\n    assets:cash\r\n\r\n2024-01-17 * Groc"
+
+	srv.StoreDocument(uri.URI("file:///test.journal"), content)
+
+	params := &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: "file:///test.journal",
+			},
+			Position: protocol.Position{Line: 4, Character: 17},
+		},
+	}
+
+	result, err := srv.completion(context.Background(), params)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Contains(t, extractLabels(result.Items), "Grocery Store")
+}
+
 func TestExtractQueryText_PayeeWithTab(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -2653,7 +2810,8 @@ func TestExtractQueryText_PayeeWithTab(t *testing.T) {
 	}{
 		{"tab separator", "2024-01-15\tgrocery", 18, "grocery"},
 		{"tab then empty", "2024-01-15\t", 11, ""},
-		{"tab with status marker", "2024-01-15\t* grocery", 20, "* grocery"},
+		{"tab with status marker", "2024-01-15\t* grocery", 20, "grocery"},
+		{"tabs around status marker", "2024-01-15\t*\tgrocery", 20, "grocery"},
 	}
 
 	for _, tt := range tests {
@@ -2675,6 +2833,70 @@ func TestCalculateTextEditRange_PayeeWithTab(t *testing.T) {
 	}{
 		{"tab separator", "2024-01-15\tgrocery", 18, 11, 18},
 		{"tab then status marker", "2024-01-15\t* grocery", 20, 13, 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pos := protocol.Position{Line: 0, Character: tt.char}
+			r := calculateTextEditRange(tt.content, pos, ContextPayee)
+			require.NotNil(t, r)
+			assert.Equal(t, tt.wantStart, r.Start.Character)
+			assert.Equal(t, tt.wantEnd, r.End.Character)
+		})
+	}
+}
+
+func TestPayeeStartOffset(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		byteCol  int
+		expected int
+	}{
+		{"no whitespace before cursor", "2024-01-15", 10, 10},
+		{"plain payee", "2024-01-15 Groc", 15, 11},
+		{"cleared status", "2024-01-15 * Groc", 17, 13},
+		{"pending status", "2024-01-15 ! Groc", 17, 13},
+		{"status without space", "2024-01-15 *G", 13, 12},
+		{"cursor right after status", "2024-01-15 * ", 13, 13},
+		{"status and code", "2024-01-15 * (CHK1) Groc", 24, 20},
+		{"code without status", "2024-01-15 (INV-1) Groc", 23, 19},
+		{"unclosed code", "2024-01-15 * (CH", 16, 13},
+		{"cursor inside code", "2024-01-15 * (CHK1) Groc", 17, 13},
+		{"tabs around status", "2024-01-15\t*\tGroc", 17, 13},
+		{"cursor before status", "2024-01-15 * Groc", 11, 11},
+		{"secondary date", "2024-01-15=2024-01-20 * Groc", 28, 24},
+		{"multiple spaces", "2024-01-15   *   Groc", 21, 17},
+		{"only one status mark skipped", "2024-01-15 ** Groc", 18, 12},
+		{"cyrillic payee", "2024-01-15 * Продукты", 29, 13},
+		{"byteCol past end of line", "2024-01-15 * Groc", 99, 13},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, payeeStartOffset(tt.line, tt.byteCol))
+		})
+	}
+}
+
+func TestCalculateTextEditRange_PayeeWithStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		char      uint32
+		wantStart uint32
+		wantEnd   uint32
+	}{
+		{"status mark then space", "2024-01-15 * grocery", 20, 13, 20},
+		{"status mark without space", "2024-01-15 *grocery", 19, 12, 19},
+		{"cursor right after status mark", "2024-01-15 *", 12, 12, 12},
+		{"status mark and transaction code", "2024-01-15 * (CHK1) grocery", 27, 20, 27},
+		{"transaction code without status mark", "2024-01-15 (INV-1) grocery", 26, 19, 26},
+		{"unclosed transaction code", "2024-01-15 * (CH", 16, 13, 16},
+		{"cyrillic payee after status mark", "2024-01-15 * Пятёроч", 20, 13, 20},
+		{"cursor mid payee", "2024-01-15 * Grocery Store", 17, 13, 26},
+		{"payee with trailing comment", "2024-01-15 * Groc ; note", 17, 13, 17},
+		{"no whitespace before cursor", "2024-01-15", 10, 10, 10},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #72.

## Problem

Payee completion returned no items when the transaction header carried a status mark:

```
2026-08-14 * <cursor>    -> nothing
2026-08-14 <cursor>      -> payees
```

## Cause

The context classifier was fine -- `determineCompletionContext` does return `ContextPayee`
for that position. The query text was not: `extractQueryText` took everything after the first
whitespace, so the query became `"* "`. That query fed the subsequence matcher in
`filterAndScoreFuzzyMatch`, which never matches a payee that contains no asterisk, so every
item was dropped. The non-fuzzy prefix filter and the `FilterText` sent to the client failed
the same way.

`calculateTextEditRange` already skipped the status mark, in a loop of its own, so the two
places computing the same offset had drifted apart -- and neither knew about the optional
transaction code, which broke `2026-08-14 * (CHK1) Groc` and `2026-08-14 (INV-1) Groc` as well.

## Change

Compute the offset once, in `payeeStartOffset`, and call it from both places. It walks the
header grammar `DATE [STATUS] [(CODE)] DESCRIPTION` over the bytes before the cursor only,
so a header still being typed works: an unterminated code is left in place, because the
cursor is still inside it. Exactly one status mark is skipped, matching hledger; the old loop
swallowed any run of asterisks, exclamation marks and spaces.

One existing expectation changed: `TestExtractQueryText_PayeeWithTab` pinned the buggy
`"* grocery"` query and now expects `"grocery"`.

## Verification

`go build ./...`, `go test ./...` and `golangci-lint run ./...` all pass.

New coverage: `TestPayeeStartOffset` (17 cases), status/code cases in
`TestExtractQueryText_Payee` and the new `TestCalculateTextEditRange_PayeeWithStatus`, plus
end-to-end `TestCompletion_PayeeAfterStatusMark` (cleared, pending, partial payee, no space
after the mark, code with and without a status) and `TestCompletion_PayeeAfterStatusMarkCRLF`.
Non-ASCII payees (Cyrillic, CJK) are covered, since the offsets are byte-based and converted
to UTF-16 by `lsputil.ByteOffsetToUTF16`.
