### PR TITLE
fix(inline-completion): prioritize recent templates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,10 @@ Enable or disable specific LSP features.
 | `hledger.features.codeLens` | `false` | Balance check indicators on transactions |
 | `hledger.features.inlayHints` | `true` | Inlay hints for inferred amounts and optional balance facts |
 
+Inline completion chooses the posting pattern used most often in the last 50
+transactions for the payee. Suggestions refresh after document edits and
+watched journal-file changes; saving is not required.
+
 ## Inlay hints
 
 | Setting | Default | Description |

--- a/internal/analyzer/indexer.go
+++ b/internal/analyzer/indexer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/juev/hledger-lsp/internal/ast"
 )
 
+const recentTemplateTransactionLimit = 50
+
 func CollectAccounts(journal *ast.Journal) *AccountIndex {
 	idx := NewAccountIndex()
 	seen := make(map[string]bool)
@@ -214,7 +216,9 @@ func CollectPayeeTemplates(journal *ast.Journal) map[string][]PostingTemplate {
 		patternCount := make(map[string]int)
 		patternLastIdx := make(map[string]int)
 
-		for i, tx := range txs {
+		firstRecentIdx := max(0, len(txs)-recentTemplateTransactionLimit)
+		for i := firstRecentIdx; i < len(txs); i++ {
+			tx := txs[i]
 			patternCount[tx.pattern]++
 			patternLastIdx[tx.pattern] = i
 		}

--- a/internal/analyzer/indexer_test.go
+++ b/internal/analyzer/indexer_test.go
@@ -1,6 +1,8 @@
 package analyzer
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -483,6 +485,28 @@ func TestCollectPayeeTemplates_MostFrequentNotLast(t *testing.T) {
 		"Should select most frequent pattern (assets:cash 3 times) not last (assets:bank)")
 	assert.Equal(t, "30", postings[0].Amount,
 		"Should use amount from the LAST transaction with the most frequent pattern")
+}
+
+func TestCollectPayeeTemplates_PrefersMostFrequentRecentPattern(t *testing.T) {
+	var input strings.Builder
+	for i := range 120 {
+		fmt.Fprintf(&input, "2024-01-%02d Store\n    expenses:food  $10\n    assets:cash\n\n", i%28+1)
+	}
+	for i := range 30 {
+		fmt.Fprintf(&input, "2024-02-%02d Store\n    expenses:food  $20\n    assets:bank\n\n", i%28+1)
+	}
+
+	journal, errs := parser.Parse(input.String())
+	require.Empty(t, errs)
+
+	templates := CollectPayeeTemplates(journal)
+
+	require.Contains(t, templates, "Store")
+	postings := templates["Store"]
+	require.Len(t, postings, 2)
+	assert.Equal(t, "assets:bank", postings[1].Account,
+		"assets:bank appears most often in the last 50 Store transactions")
+	assert.Equal(t, "20", postings[0].Amount)
 }
 
 func TestCollectPayeeTemplates_DeterministicWithMultiplePatterns(t *testing.T) {

--- a/internal/server/inline_completion.go
+++ b/internal/server/inline_completion.go
@@ -19,6 +19,11 @@ import (
 // - Secondary date after = is handled separately by space detection
 var dateRegex = regexp.MustCompile(`^(\d{4}[-/\.])?\d{1,2}[-/\.]\d{1,2}`)
 
+type cachedPayeeTemplates struct {
+	content   string
+	templates map[string][]analyzer.PostingTemplate
+}
+
 func (s *Server) InlineCompletion(_ context.Context, params *protocol.InlineCompletionParams) (protocol.InlineCompletionResult, error) {
 	content, ok := s.GetDocument(params.TextDocument.URI)
 	if !ok {
@@ -59,8 +64,7 @@ func (s *Server) InlineCompletion(_ context.Context, params *protocol.InlineComp
 
 	// Compute alignment columns from the current document so ghost text
 	// targets the same columns that Format Document would produce. Parsing
-	// here is independent of the payee-template path (which is cached and
-	// may not reflect the latest content); for inline completion latency,
+	// here is independent of the payee-template path; for inline completion latency,
 	// this is the same Parse cost as the cache-miss path of getPayeeTemplates.
 	journal, _ := s.cachedJournal(params.TextDocument.URI, content)
 	commodityFormats := formatter.ExtractCommodityFormats(journal.Directives)
@@ -85,20 +89,38 @@ func emptyInlineCompletionList() *protocol.InlineCompletionList {
 
 func (s *Server) getPayeeTemplates(uri uri.URI, content string) map[string][]analyzer.PostingTemplate {
 	if cached, ok := s.payeeTemplatesCache.Load(uri); ok {
-		if templates, ok := cached.(map[string][]analyzer.PostingTemplate); ok {
-			return templates
+		if cachedTemplates, ok := cached.(*cachedPayeeTemplates); ok && cachedTemplates.content == content {
+			return cachedTemplates.templates
 		}
 	}
 
 	var result *analyzer.AnalysisResult
-	if resolved := s.getWorkspaceResolved(uri); resolved != nil {
-		result = s.analyzer.AnalyzeResolved(resolved)
-	} else {
-		journal, _ := s.cachedJournal(uri, content)
-		result = s.analyzer.Analyze(journal)
+	if s.workspace != nil {
+		resolved := s.workspace.GetResolvedForFile(uriToPath(uri))
+		if resolved != nil {
+			result = s.analyzer.AnalyzeResolved(resolved)
+		}
+	}
+	if result == nil {
+		path := uriToPath(uri)
+		if path == "" {
+			journal, _ := s.cachedJournal(uri, content)
+			result = s.analyzer.Analyze(journal)
+		} else {
+			resolved, _ := s.loader.LoadFromContent(path, content)
+			if resolved != nil {
+				result = s.analyzer.AnalyzeResolved(resolved)
+			} else {
+				journal, _ := s.cachedJournal(uri, content)
+				result = s.analyzer.Analyze(journal)
+			}
+		}
 	}
 
-	s.payeeTemplatesCache.Store(uri, result.PayeeTemplates)
+	s.payeeTemplatesCache.Store(uri, &cachedPayeeTemplates{
+		content:   content,
+		templates: result.PayeeTemplates,
+	})
 	return result.PayeeTemplates
 }
 

--- a/internal/server/inline_completion_test.go
+++ b/internal/server/inline_completion_test.go
@@ -644,6 +644,41 @@ func TestInlineCompletion_CacheInvalidatedOnSave(t *testing.T) {
 		"should return updated second posting after DidSave invalidates cache")
 }
 
+func TestInlineCompletion_CacheInvalidatedOnChange(t *testing.T) {
+	ts := newTestServer()
+	uri := uri.URI("file:///test.journal")
+	content1 := `2024-01-10 Grocery Store
+    expenses:food:groceries  $50.00
+    assets:cash
+
+2024-01-15 Grocery Store
+`
+	require.NoError(t, ts.openDocument(uri, content1))
+
+	params := inlineCompletionParams(uri, 5, 0)
+	result1, err := ts.InlineCompletion(context.Background(), params)
+	require.NoError(t, err)
+	require.Len(t, inlineCompletionItems(t, result1), 1)
+	assert.Contains(t, inlineCompletionItems(t, result1)[0].InsertText, "expenses:food:groceries")
+
+	content2 := `2024-01-10 Grocery Store
+    expenses:food:supermarket  $100.00
+    assets:bank
+
+2024-01-15 Grocery Store
+`
+	content2 = strings.ReplaceAll(content2, "\n", "\r\n")
+	require.NoError(t, ts.changeDocument(uri, []protocol.TextDocumentContentChangeEvent{
+		&protocol.TextDocumentContentChangeWholeDocument{Text: content2},
+	}))
+
+	result2, err := ts.InlineCompletion(context.Background(), params)
+	require.NoError(t, err)
+	require.Len(t, inlineCompletionItems(t, result2), 1)
+	assert.Contains(t, inlineCompletionItems(t, result2)[0].InsertText, "expenses:food:supermarket")
+	assert.Contains(t, inlineCompletionItems(t, result2)[0].InsertText, "assets:bank")
+}
+
 func TestInlineCompletion_DeterministicResults(t *testing.T) {
 	srv := NewServer()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -300,6 +300,7 @@ func (s *Server) Exit(ctx context.Context) error {
 func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
 	content := textutil.NormalizeLineEndings(params.TextDocument.Text)
 	s.documents.Store(params.TextDocument.URI, content)
+	s.payeeTemplatesCache.Clear()
 	s.alignmentCache.Delete(params.TextDocument.URI)
 	s.invalidateDocText(params.TextDocument.URI)
 	if s.workspace != nil && s.loader.FileSizeError(content) == nil {
@@ -335,6 +336,7 @@ func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDo
 			}
 		}
 		s.documents.Store(params.TextDocument.URI, content)
+		s.payeeTemplatesCache.Clear()
 		s.alignmentCache.Delete(params.TextDocument.URI)
 		if s.workspace != nil {
 			if path := uriToPath(params.TextDocument.URI); path != "" {
@@ -368,6 +370,7 @@ func (s *Server) clearAlignmentCache() {
 func (s *Server) DidClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
 	s.cancelDiagnostics(params.TextDocument.URI)
 	s.documents.Delete(params.TextDocument.URI)
+	s.payeeTemplatesCache.Clear()
 	s.alignmentCache.Delete(params.TextDocument.URI)
 	s.tokenCache.delete(params.TextDocument.URI)
 	s.invalidateParseCache(params.TextDocument.URI)
@@ -384,7 +387,7 @@ func (s *Server) DidClose(ctx context.Context, params *protocol.DidCloseTextDocu
 }
 
 func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocumentParams) error {
-	s.payeeTemplatesCache.Delete(params.TextDocument.URI)
+	s.payeeTemplatesCache.Clear()
 	s.alignmentCache.Delete(params.TextDocument.URI)
 
 	if s.workspace != nil {
@@ -768,6 +771,9 @@ func (s *Server) DidChangeWatchedFiles(ctx context.Context, params *protocol.Did
 		}
 
 		s.loader.InvalidateFile(path)
+		if filetype.IsJournalPath(path) {
+			s.payeeTemplatesCache.Clear()
+		}
 		if filetype.IsRules(path) {
 			s.rulesLoader.InvalidateFile(path)
 		}

--- a/internal/server/watched_files_test.go
+++ b/internal/server/watched_files_test.go
@@ -104,3 +104,55 @@ func TestDidChangeWatchedFiles_SkipsOpenDocuments(t *testing.T) {
 
 	assert.Equal(t, beforeCount, afterCount, "should not republish for open documents")
 }
+
+func TestDidChangeWatchedFiles_InvalidatesIncludedTemplateCache(t *testing.T) {
+	t.Setenv("LEDGER_FILE", "")
+	t.Setenv("HLEDGER_JOURNAL", "")
+	tmpDir := t.TempDir()
+
+	childPath := filepath.Join(tmpDir, "child.journal")
+	childContent1 := `2024-01-01 Grocery
+    expenses:food  $10
+    assets:cash
+`
+	require.NoError(t, os.WriteFile(childPath, []byte(childContent1), 0o644))
+
+	mainPath := filepath.Join(tmpDir, "main.journal")
+	mainContent := `include child.journal
+
+2024-01-02 Grocery
+`
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainContent), 0o644))
+
+	ts := newTestServer()
+	loader := include.NewLoader()
+	ts.workspace = workspace.NewWorkspace(tmpDir, loader)
+	ts.loader = loader
+	require.NoError(t, ts.workspace.Initialize())
+
+	mainURI := uri.File(mainPath)
+	require.NoError(t, ts.openDocument(mainURI, mainContent))
+	params := inlineCompletionParams(mainURI, 3, 0)
+
+	result1, err := ts.InlineCompletion(context.Background(), params)
+	require.NoError(t, err)
+	require.Len(t, inlineCompletionItems(t, result1), 1)
+	assert.Contains(t, inlineCompletionItems(t, result1)[0].InsertText, "assets:cash")
+
+	childContent2 := `2024-01-01 Grocery
+    expenses:food  $20
+    assets:bank
+`
+	require.NoError(t, os.WriteFile(childPath, []byte(childContent2), 0o644))
+	require.NoError(t, ts.DidChangeWatchedFiles(context.Background(), &protocol.DidChangeWatchedFilesParams{
+		Changes: []protocol.FileEvent{{
+			URI:  uri.File(childPath),
+			Type: protocol.FileChangeTypeChanged,
+		}},
+	}))
+
+	result2, err := ts.InlineCompletion(context.Background(), params)
+	require.NoError(t, err)
+	require.Len(t, inlineCompletionItems(t, result2), 1)
+	assert.Contains(t, inlineCompletionItems(t, result2)[0].InsertText, "assets:bank")
+}


### PR DESCRIPTION
Inline completion ranked posting patterns across the whole payee history and retained cached suggestions until save. Recent patterns and edits to included journals could therefore be ignored.

## Changes
- Rank each payee's posting patterns by frequency in its latest 50 transactions.
- Bind template cache entries to document content and rebuild standalone documents from the current buffer.
- Clear template caches after document lifecycle events and watched journal-file changes.
- Cover recent-pattern selection, CRLF edits, and included-file updates.

## Verification
- `go test -race ./...`
- `go build ./...`
- `go test ./internal/benchmark/... -run TestNFR`
- `golangci-lint run --new-from-rev=origin/main ./...`

The full `golangci-lint run ./...` remains blocked by seven existing `SA1019` diagnostics for deprecated `InitializeParams.RootURI` in unchanged server tests.

## Code Pointers
- `internal/analyzer/indexer.go`: `CollectPayeeTemplates`
- `internal/server/inline_completion.go`: `getPayeeTemplates`
- `internal/server/server.go`: document and watched-file handlers
