### PR TITLE
Fix prefix commodities in balance assertions

### DIFF
--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -507,6 +507,9 @@ func (l *Lexer) scanAt() Token {
 func (l *Lexer) scanEquals() Token {
 	startPos := l.position()
 	l.advance()
+	// A balance assertion starts a new amount, possibly with a prefix commodity.
+	l.afterNumber = false
+	l.afterSign = false
 
 	if l.pos < len(l.input) && l.peek() == '=' {
 		l.advance()

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -750,6 +750,29 @@ func TestParser_BalanceAssertion(t *testing.T) {
 	assert.True(t, p.BalanceAssertion.Amount.Quantity.Equal(decimal.NewFromInt(1000)))
 }
 
+func TestParser_BalanceAssertionCommodityPrefix(t *testing.T) {
+	for _, operator := range []string{"=", "==", "=*", "==*"} {
+		for _, amount := range []string{"USD5.00", "5.00 USD", "5.00", ""} {
+			for _, balance := range []string{"USD10.00", "USD 10.00"} {
+				t.Run(amount+operator+balance, func(t *testing.T) {
+					input := "2024-01-15 check balance\n    Assets:Cash   " + amount + " " + operator + " " + balance + "\n    Equity:Opening"
+					journal, errs := Parse(input)
+					require.Empty(t, errs)
+					require.Len(t, journal.Transactions, 1)
+					require.Len(t, journal.Transactions[0].Postings, 2)
+					ba := journal.Transactions[0].Postings[0].BalanceAssertion
+					require.NotNil(t, ba)
+					assert.Equal(t, operator == "==" || operator == "==*", ba.IsStrict)
+					assert.Equal(t, operator == "=*" || operator == "==*", ba.IsInclusive)
+					assert.Equal(t, "USD", ba.Amount.Commodity.Symbol)
+					assert.Equal(t, ast.CommodityLeft, ba.Amount.Commodity.Position)
+					assert.True(t, ba.Amount.Quantity.Equal(decimal.NewFromInt(10)))
+				})
+			}
+		}
+	}
+}
+
 func TestParser_StrictBalanceAssertion(t *testing.T) {
 	input := `2024-01-15 check balance
     assets:checking  $100 == $1000


### PR DESCRIPTION
Reset lexer amount state at assertion operators so USD5.00 = USD10.00 parses correctly. Add regression coverage for all four assertion operators with spaced and unspaced commodity prefixes.

Validation: go test ./...